### PR TITLE
Removed unnecessary synchronization.

### DIFF
--- a/src/main/java/com/p6spy/engine/common/P6LogQuery.java
+++ b/src/main/java/com/p6spy/engine/common/P6LogQuery.java
@@ -284,7 +284,7 @@ public class P6LogQuery {
     }
 
     // this is an internal procedure used to actually write the log information
-    static protected synchronized void doLog(int connectionId, long elapsed, String category, String prepared, String sql) {
+    static protected void doLog(int connectionId, long elapsed, String category, String prepared, String sql) {
         if (logger != null) {
             java.util.Date now = P6Util.timeNow();
             SimpleDateFormat sdf = P6SpyOptions.getDateformatter();
@@ -320,40 +320,7 @@ public class P6LogQuery {
             //lastEntry = logEntry;
         }
 
-        /*
-	java.util.Date now = P6Util.timeNow();
-	SimpleDateFormat sdf = P6SpyOptions.getDateformatter();
-	String logEntry;
-	if (sdf == null) {
-	    logEntry = Long.toString(now.getTime());
-	} else {
-	    logEntry = sdf.format(new java.util.Date(now.getTime())).trim();
-	}
 
-        logEntry += "|"+elapsed+"|"+(connectionId==-1 ? "" : String.valueOf(connectionId))+"|"+category+"|"+prepared+"|"+sql;
-        qlog.println(logEntry);
-        boolean stackTrace = P6SpyOptions.getStackTrace();
-        String stackTraceClass = P6SpyOptions.getStackTraceClass();
-        if(stackTrace) {
-            if(stackTraceClass == null) {
-                Exception e = new Exception();
-                e.printStackTrace(qlog);
-            }
-            else {
-                ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-                PrintStream printStream = new PrintStream(byteStream);
-                Exception e = new Exception("P6Spy Stack Trace Log");
-                e.printStackTrace(printStream);
-                String stack = byteStream.toString();
-                if(stack.indexOf(stackTraceClass) != -1) {
-                    lastStack = stack;
-                    e.printStackTrace(qlog);
-                }
-            }
-        }
-
-        lastEntry = logEntry;
-         */
     }
 
     static boolean isLoggable(String sql) {

--- a/src/main/java/com/p6spy/engine/common/P6SpyOptions.java
+++ b/src/main/java/com/p6spy/engine/common/P6SpyOptions.java
@@ -119,7 +119,6 @@ public class P6SpyOptions extends P6Options {
 
     private static String dateformat;
 
-    private static SimpleDateFormat dateformatter;
 
     private static String includecategories;
 
@@ -291,11 +290,6 @@ public class P6SpyOptions extends P6Options {
 
     public static void setDateformat(String _dateformat) {
         dateformat = _dateformat;
-        if (_dateformat == null || _dateformat.equals("")) {
-            dateformatter = null;
-        } else {
-            dateformatter = new SimpleDateFormat(_dateformat);
-        }
     }
 
     public static String getDateformat() {
@@ -303,7 +297,11 @@ public class P6SpyOptions extends P6Options {
     }
 
     public static SimpleDateFormat getDateformatter() {
-        return dateformatter;
+        if (dateformat == null || dateformat.equals("")) {
+            return null;
+        } else {
+            return new SimpleDateFormat(dateformat);
+        }
     }
 
     public static boolean getStackTrace() {


### PR DESCRIPTION
Under very high load our application was slowed down 63% with logger p6spy set to info.  This bottleneck went away when we removed p6spy instrumentation.  We run p6spy all the time in prod

I removed the synchronized keyword from P6LogQuery.doLog and made sure that access to the date format was thread safe.  When I did this performance went back to nearly the same as with no p6spy.
