### PR TITLE
Issue #74 - Switch to CGLIB proxies

### DIFF
--- a/p6spy/pom.xml
+++ b/p6spy/pom.xml
@@ -167,7 +167,7 @@
               </includes>
             </relocation>
           </relocations>
-          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
The shaded p6spy.jar artifact will be included in the distribution instead of the original version.
