### PR TITLE
P6LogOptions: for exclude/include and sqlexpression performance improvements

### DIFF
--- a/src/main/java/com/p6spy/engine/common/P6LogQuery.java
+++ b/src/main/java/com/p6spy/engine/common/P6LogQuery.java
@@ -37,8 +37,6 @@ import com.p6spy.engine.spy.option.P6OptionChangedListener;
 
 public class P6LogQuery implements P6OptionChangedListener {
   
-  private static PrintStream qlog;
-
   protected static P6Logger logger;
 
   static {
@@ -163,34 +161,22 @@ public class P6LogQuery implements P6OptionChangedListener {
   
   static boolean isQueryOk(final String sql) {
     final P6LogLoadableOptions opts = P6LogOptions.getActiveInstance();
-    if (opts.getSQLExpression() != null) {
-      return isSqlOk(sql);
+    
+    final Pattern sqlExpressionPattern = opts.getSQLExpressionPattern();
+    if (sqlExpressionPattern != null) {
+      return sqlExpressionPattern.matcher(sql).matches();
     } 
+    
+    final Pattern includePattern = opts.getIncludeTablesPattern();
+    final Pattern excludePattern = opts.getExcludeTablesPattern();
     
     final Set<String> includeTables = opts.getIncludeTables();
     final Set<String> excludeTables = opts.getExcludeTables();
     
-    return ((includeTables == null || includeTables.isEmpty() || isTableFound(sql, includeTables))) && !isTableFound(sql, excludeTables);
-  }
-
-  static boolean isSqlOk(final String sql) {
-    String sqlexpression = P6LogOptions.getActiveInstance().getSQLExpression();
-    return Pattern.matches(sqlexpression, sql);
-  }
-
-  static boolean isTableFound(final String sql, final Set<String> tables) {
     final String sqlLowercased = sql.toLowerCase();
-
-    if (tables != null) {
-      for (String table : tables) {
-        // TODO [Peter Butkovic] improve performance by precompiling + caching the patterns
-        if (Pattern.matches("select.*from(.*" + table + ".*)(where|;|$)", sqlLowercased)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
+    
+    return (includeTables == null || includeTables.isEmpty() || includePattern.matcher(sqlLowercased).matches()) 
+        && (excludeTables == null || excludeTables.isEmpty() || !excludePattern.matcher(sqlLowercased).matches());
   }
 
   // ----------------------------------------------------------------------------------------------------------

--- a/src/main/java/com/p6spy/engine/logging/P6LogLoadableOptions.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogLoadableOptions.java
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package com.p6spy.engine.logging;
 
+import java.util.regex.Pattern;
+
 import com.p6spy.engine.spy.P6LoadableOptions;
 
 public interface P6LogLoadableOptions extends P6LoadableOptions, P6LogOptionsMBean {
@@ -24,4 +26,11 @@ public interface P6LogLoadableOptions extends P6LoadableOptions, P6LogOptionsMBe
   void setFilter(String filter);
 
   void setExecutionThreshold(String executionThreshold);
+  
+  Pattern getIncludeTablesPattern();
+
+  Pattern getExcludeTablesPattern();
+
+  Pattern getSQLExpressionPattern();
+
 }

--- a/src/main/java/com/p6spy/engine/spy/option/P6OptionsRepository.java
+++ b/src/main/java/com/p6spy/engine/spy/option/P6OptionsRepository.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.p6spy.engine.common.P6Util;
 
@@ -73,6 +74,8 @@ public class P6OptionsRepository {
       throw new IllegalArgumentException("please call the setSet() method instead!");
     } else if (type.isAssignableFrom(Collection.class) || type.isAssignableFrom(List.class)) {
       throw new IllegalArgumentException("type not supported:" + type.getName());
+    } else if (type.isAssignableFrom(Pattern.class)) {
+      return Pattern.compile(value.toString());
     } else {
       Object instance;
       try {

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
@@ -101,8 +101,11 @@ public class P6TestOptionDefaults {
     Assert.assertFalse(opts.getFilter());
     Assert.assertNull(opts.getIncludeTables());
     Assert.assertNull(opts.getExcludeTables());
+    Assert.assertNull(opts.getIncludeTablesPattern());
+    Assert.assertNull(opts.getExcludeTablesPattern());
     Assert.assertNull(opts.getInclude());
     Assert.assertNull(opts.getExclude());
+    Assert.assertNull(opts.getSQLExpressionPattern());
   }
 
   @Test

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsRepository.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsRepository.java
@@ -18,6 +18,7 @@ package com.p6spy.engine.spy.option;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,6 +47,8 @@ public class P6TestOptionsRepository {
         SingleLineFormat.class.getName()) instanceof MessageFormattingStrategy);
     Assert.assertTrue(optRepo.parse(MessageFormattingStrategy.class,
         MultiLineFormat.class.getName()) instanceof MessageFormattingStrategy);
+    Assert.assertTrue(optRepo.parse(Pattern.class,
+        "somepattern") instanceof Pattern);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
P6LogOptions: for exclude/include and sqlexpression we compile Pattern eagerly => to improve performance; tests for these added; fixed #78
