### PR TITLE
Issue #122 - P6LogPreparedStatementExecuteDelegate should also wrap Resu...

### DIFF
--- a/src/main/java/com/p6spy/engine/logging/P6LogPreparedStatementExecuteDelegate.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogPreparedStatementExecuteDelegate.java
@@ -18,8 +18,10 @@ package com.p6spy.engine.logging;
 import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.common.PreparedStatementInformation;
 import com.p6spy.engine.proxy.Delegate;
+import com.p6spy.engine.proxy.ProxyFactory;
 
 import java.lang.reflect.Method;
+import java.sql.ResultSet;
 
 class P6LogPreparedStatementExecuteDelegate implements Delegate {
   private final PreparedStatementInformation preparedStatementInformation;
@@ -33,9 +35,15 @@ class P6LogPreparedStatementExecuteDelegate implements Delegate {
     long startTime = System.currentTimeMillis();
 
     try {
-      return method.invoke(target, args);
-    }
-    finally {
+      Object result = method.invoke(target, args);
+      
+      if( result != null && result instanceof ResultSet) {
+        P6LogResultSetInvocationHandler resultSetInvocationHandler = new P6LogResultSetInvocationHandler((ResultSet)result, preparedStatementInformation);
+        result = ProxyFactory.createProxy((ResultSet) result, ResultSet.class, resultSetInvocationHandler);
+      }
+      return result;
+      
+    } finally {
       P6LogQuery.logElapsed(preparedStatementInformation.getConnectionId(), startTime, "statement",
           preparedStatementInformation.getStatementQuery(), preparedStatementInformation.getPreparedStatementQuery());
     }

--- a/src/main/java/com/p6spy/engine/logging/P6LogResultSetGetColumnValueDelegate.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogResultSetGetColumnValueDelegate.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package com.p6spy.engine.logging;
 
-import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.common.ResultSetInformation;
 import com.p6spy.engine.proxy.Delegate;
 
@@ -47,16 +46,10 @@ class P6LogResultSetGetColumnValueDelegate implements Delegate {
    */
   @Override
   public Object invoke(final Object target, final Method method, final Object[] args) throws Throwable {
-    long startTime = System.currentTimeMillis();
     // the first argument will always be the column index or the column name
     String columnName = String.valueOf(args[0]);
-    Object result;
-    try {
-      result = method.invoke(target, args);
-      resultSetInformation.setColumnValue(columnName, result);
-      return result;
-    } finally {
-      P6LogQuery.logElapsed(resultSetInformation.getConnectionId(), startTime, "result", resultSetInformation.getPreparedQuery(), resultSetInformation.getQuery());
-    }
+    Object result = method.invoke(target, args);
+    resultSetInformation.setColumnValue(columnName, result);
+    return result;
   }
 }

--- a/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
@@ -15,27 +15,21 @@ limitations under the License.
 */
 package com.p6spy.engine.spy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
+import com.p6spy.engine.logging.P6LogOptions;
+import com.p6spy.engine.spy.appender.MultiLineFormat;
+import com.p6spy.engine.spy.appender.SingleLineFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import com.p6spy.engine.logging.P6LogOptions;
-import com.p6spy.engine.spy.appender.MultiLineFormat;
-import com.p6spy.engine.spy.appender.SingleLineFormat;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class P6TestCommon extends P6TestFramework {
@@ -265,16 +259,19 @@ public class P6TestCommon extends P6TestFramework {
       while (resultSet.next()) {
         String col1 = resultSet.getString("col1");
         assertTrue(col1.startsWith("foo"));
-        if (resultCategoryNotExcluded) {
-          assertTrue("calling get*() is supposed to cause \"result\" logged", super.getLastLogEntry()
-              .contains("| result |"));
-          assertTrue(super.getLastLogEntry().contains(query));
+      }
+      int resultCount = 0;
+      int resultSetCount = 0;
+      for( String logMessage : getLogEnties() ) {
+        if( logMessage.contains("result") && !logMessage.contains("resultset")) {
+          resultCount++;
+        } else {
+          resultSetCount++;
         }
       }
-      if (resultsetCategoryNotExcluded) {
-        assertTrue(super.getLastButOneLogEntry().contains("| resultset |"));
-        assertTrue(super.getLastButOneLogEntry().contains(query));
-      }
+      assertEquals("incorrect number of log messages", resultCategoryNotExcluded ? 2 : 0, resultCount);
+      assertEquals("incorrect number of log messages", resultsetCategoryNotExcluded ? 2 :0 , resultSetCount);
+      
       resultSet.close();
       // reset back to original setup
       P6LogOptions.getActiveInstance().setExcludecategories("resultset,result");

--- a/src/test/java/com/p6spy/engine/spy/P6TestFramework.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestFramework.java
@@ -15,6 +15,15 @@ limitations under the License.
 */
 package com.p6spy.engine.spy;
 
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.spy.appender.P6TestLogger;
+import com.p6spy.engine.spy.option.SpyDotProperties;
+import com.p6spy.engine.test.P6TestOptions;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.runners.Parameterized.Parameters;
+
 import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.IOException;
@@ -26,16 +35,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
-
-import org.apache.log4j.Logger;
-import org.junit.Before;
-import org.junit.runners.Parameterized.Parameters;
-
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.common.P6Util;
-import com.p6spy.engine.spy.appender.P6TestLogger;
-import com.p6spy.engine.spy.option.SpyDotProperties;
-import com.p6spy.engine.test.P6TestOptions;
+import java.util.List;
 
 public abstract class P6TestFramework {
   private static final Logger log = Logger.getLogger(P6TestFramework.class);
@@ -147,6 +147,11 @@ public abstract class P6TestFramework {
   protected int getLogEntiesCount() {
     failOnNonP6TestLoggerUsage();
     return ((P6TestLogger) P6LogQuery.getLogger()).getLogs().size();
+  }
+
+  protected List<String> getLogEnties() {
+    failOnNonP6TestLoggerUsage();
+    return ((P6TestLogger) P6LogQuery.getLogger()).getLogs();
   }
 
   protected String getLastButOneLogEntry() {

--- a/src/test/java/com/p6spy/engine/spy/P6TestPreparedStatement.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestPreparedStatement.java
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package com.p6spy.engine.spy;
 
+import net.sf.cglib.proxy.Proxy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,109 +33,131 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class P6TestPreparedStatement extends P6TestFramework {
 
-    public P6TestPreparedStatement(String db) throws SQLException, IOException {
-      super(db);
-    }
+  public P6TestPreparedStatement(String db) throws SQLException, IOException {
+    super(db);
+  }
 
-    @Before
-    public void setUpPreparedStatement() {
-        try {
-            Statement statement = connection.createStatement();
-            dropPrepared(statement);
-            statement.execute("create table prepstmt_test (col1 varchar(255), col2 integer)");
-        } catch (Exception e) {
-            fail(e.getMessage());
+  @Before
+  public void setUpPreparedStatement() {
+    try {
+      Statement statement = connection.createStatement();
+      dropPrepared(statement);
+      statement.execute("create table prepstmt_test (col1 varchar(255), col2 integer)");
+
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testExecuteQuery() {
+    try {
+      // insert test data
+      String update = "insert into prepstmt_test values (?, ?)";
+      PreparedStatement prep = getPreparedStatement(update);
+      prep.setString(1, "execQueryTest");
+      prep.setInt(2, 1);
+      prep.executeUpdate();
+      prep.setString(1, "execQueryTest");
+      prep.setInt(2, 2);
+      prep.executeUpdate();
+      
+      String query = "select * from prepstmt_test where col1 = ?";
+      prep = getPreparedStatement(query);
+      prep.setString(1, "execQueryTest");
+      ResultSet rs = prep.executeQuery();
+      
+      // verify that we got back a proxy for the result set
+      assertTrue("Resultset was not a proxy", Proxy.isProxyClass(rs.getClass()));
+      
+      // verify the log message for the select
+      assertTrue(getLastLogEntry().contains(query));
+      
+    } catch (Exception e) {
+      fail(e.getMessage() + " due to error: " + getStackTrace(e));
+    }
+  }
+
+  @Test
+  public void testExecuteUpdate() {
+    try {
+      // test a basic insert
+      String update = "insert into prepstmt_test values (?, ?)";
+      PreparedStatement prep = getPreparedStatement(update);
+      prep.setString(1, "miller");
+      prep.setInt(2, 1);
+      prep.executeUpdate();
+      assertTrue(super.getLastLogEntry().contains(update));
+      assertTrue(super.getLastLogEntry().contains("miller"));
+      assertTrue(super.getLastLogEntry().contains("1"));
+
+
+      // test dynamic allocation of P6_MAX_FIELDS
+      int MaxFields = 10;
+      StringBuffer bigSelect = new StringBuffer(MaxFields);
+      bigSelect.append("select count(*) from prepstmt_test where");
+      for (int i = 0; i < MaxFields; i++) {
+        if (i > 0) {
+          bigSelect.append(" or ");
         }
+        bigSelect.append(" col2=?");
+      }
+      prep = getPreparedStatement(bigSelect.toString());
+      for (int i = 1; i <= MaxFields; i++) {
+        prep.setInt(i, i);
+      }
+
+      // test batch inserts
+      update = "insert into prepstmt_test values (?,?)";
+      prep = getPreparedStatement(update);
+      prep.setString(1, "danny");
+      prep.setInt(2, 2);
+      prep.addBatch();
+      prep.setString(1, "denver");
+      prep.setInt(2, 3);
+      prep.addBatch();
+      prep.setString(1, "aspen");
+      prep.setInt(2, 4);
+      prep.addBatch();
+      prep.executeBatch();
+      assertTrue(super.getLastLogEntry().contains(update));
+      assertTrue(super.getLastLogEntry().contains("aspen"));
+      assertTrue(super.getLastLogEntry().contains("4"));
+
+      String query = "select count(*) from prepstmt_test";
+      prep = getPreparedStatement(query);
+      ResultSet rs = prep.executeQuery();
+      rs.next();
+      assertEquals(4, rs.getInt(1));
+    } catch (Exception e) {
+      fail(e.getMessage() + " due to error: " + getStackTrace(e));
     }
+  }
 
-    @Test
-    public void testPreparedQueryUpdate() {
-        try {
-            // test a basic insert
-            String update = "insert into prepstmt_test values (?, ?)";
-            PreparedStatement prep = getPreparedStatement(update);
-            prep.setString(1, "miller");
-            prep.setInt(2,1);
-            prep.executeUpdate();
-            assertTrue(super.getLastLogEntry().contains(update));
-            assertTrue(super.getLastLogEntry().contains("miller"));
-            assertTrue(super.getLastLogEntry().contains("1"));
-
-            // test a basic select
-            String query = "select count(*) from prepstmt_test where col2 = ?";
-            prep = getPreparedStatement(query);
-            prep.setInt(1,1);
-            ResultSet rs = prep.executeQuery();
-            assertTrue(super.getLastLogEntry().contains(query));
-            rs.next();
-            assertEquals(1, rs.getInt(1));
-
-            // test dynamic allocation of P6_MAX_FIELDS
-            int MaxFields = 10;
-            StringBuffer bigSelect = new StringBuffer(MaxFields);
-            bigSelect.append("select count(*) from prepstmt_test where");
-            for (int i = 0; i < MaxFields; i++) {
-                if (i > 0) {
-                  bigSelect.append(" or ");
-                }
-                bigSelect.append(" col2=?");
-            }
-            prep = getPreparedStatement(bigSelect.toString());
-            for (int i = 1; i <= MaxFields; i++) {
-                 prep.setInt(i, i);
-            }
-            
-            // test batch inserts
-            update = "insert into prepstmt_test values (?,?)";
-            prep = getPreparedStatement(update);
-            prep.setString(1,"danny");
-            prep.setInt(2,2);
-            prep.addBatch();
-            prep.setString(1,"denver");
-            prep.setInt(2,3);
-            prep.addBatch();
-            prep.setString(1,"aspen");
-            prep.setInt(2,4);
-            prep.addBatch();
-            prep.executeBatch();
-            assertTrue(super.getLastLogEntry().contains(update));
-            assertTrue(super.getLastLogEntry().contains("aspen"));
-            assertTrue(super.getLastLogEntry().contains("4"));
-
-            query = "select count(*) from prepstmt_test";
-            prep = getPreparedStatement(query);
-            rs = prep.executeQuery();
-            rs.next();
-            assertEquals(4, rs.getInt(1));
-        } catch (Exception e) {
-            fail(e.getMessage()+" due to error: "+getStackTrace(e));
-        }
+  @After
+  public void tearDownPreparedStatement() {
+    try {
+      Statement statement = connection.createStatement();
+      dropPrepared(statement);
+    } catch (Exception e) {
+      fail(e.getMessage());
     }
+  }
 
-    @After
-    public void tearDownPreparedStatement() {
-        try {
-            Statement statement = connection.createStatement();
-            dropPrepared(statement);
-        }  catch (Exception e) {
-            fail(e.getMessage());
-        }
-    }
+  protected void dropPrepared(Statement statement) {
+    dropPreparedStatement("drop table prepstmt_test", statement);
+  }
 
-    protected void dropPrepared(Statement statement) {
-        dropPreparedStatement("drop table prepstmt_test", statement);
+  protected void dropPreparedStatement(String sql, Statement statement) {
+    try {
+      statement.execute(sql);
+    } catch (Exception e) {
+      // we don't really care about cleanup failing
     }
+  }
 
-    protected void dropPreparedStatement(String sql, Statement statement) {
-        try {
-            statement.execute(sql);
-        } catch (Exception e) {
-            // we don't really care about cleanup failing
-        }
-    }
-
-    protected PreparedStatement getPreparedStatement(String query) throws SQLException {
-        return (connection.prepareStatement(query));
-    }
+  protected PreparedStatement getPreparedStatement(String query) throws SQLException {
+    return (connection.prepareStatement(query));
+  }
 
 }

--- a/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
@@ -21,22 +21,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.p6spy.engine.spy.appender.FileLogger;
-import com.p6spy.engine.spy.appender.P6Logger;
-
 /**
  * {@link FileLogger} extension capable of keeping history of log messages as well as the last
  * Stacktrace.<br/>
  * <br/>
  * 
- * Please note: It's logging to {@code spy.log} file
  * 
  * @author peterb
- * @author $Author: $
- * @review.state RED Rev: 0
- * @version $Rev: $
  */
-public class P6TestLogger extends FileLogger implements P6Logger {
+public class P6TestLogger extends StdoutLogger {
 
   private ArrayList<String> logs = new ArrayList<String>();
   private String lastStacktrace;
@@ -46,6 +39,7 @@ public class P6TestLogger extends FileLogger implements P6Logger {
     if (null != text) {
       logs.add(text);
     }
+    super.logText(text);
   }
 
   public List<String> getLogs() {
@@ -74,6 +68,7 @@ public class P6TestLogger extends FileLogger implements P6Logger {
     PrintWriter pw = new PrintWriter(sw);
     e.printStackTrace(pw);
     lastStacktrace = sw.toString();
+    super.logException(e);
   }
 
   public void clearLastStacktrace() {


### PR DESCRIPTION
- Result set is now wrapped in a proxy 
- Log message is no longer written when calling the get*() methods of result set (this was a bug introduced in 2.0)
- Calls to ResultSet.next() are not logged if false is returned
