### PR TITLE
change artifact version to 2.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>p6spy</groupId>
   <artifactId>p6spy</artifactId>
   <name>P6Spy</name>
-  <version>2.0-alpha-2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <organization>
 	<name>P6Spy</name>
   </organization>


### PR DESCRIPTION
I think that it is best to keep the current artifact version at 2.0.0-SNAPSHOT until the final release.  The interim alpha/beta releases will get assigned the 2.0-xxxx-x version as indicated in the milestone name.  
