### PR TITLE
SQL statements should have CR & LF removed in log when SingleLineFormat is used

### DIFF
--- a/src/main/java/com/p6spy/engine/common/P6Util.java
+++ b/src/main/java/com/p6spy/engine/common/P6Util.java
@@ -30,8 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 public class P6Util {
+    static Pattern lineBreakPattern = Pattern.compile("(\\r?\\n)+");
+    public static String singleLine(String str) {
+        return lineBreakPattern.matcher(str).replaceAll(" ");
+    }
 
     public static int parseInt(String i, int defaultValue) {
         if (i == null || i.isEmpty()) {

--- a/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
@@ -19,6 +19,8 @@
  */
 package com.p6spy.engine.spy.appender;
 
+import com.p6spy.engine.common.P6Util;
+
 /**
  * @author Quinton McCombs
  * @since 09/2013
@@ -38,6 +40,6 @@ public class SingleLineFormat implements MessageFormattingStrategy {
    */
   @Override
   public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql) {
-    return now + "|" + elapsed + "|" + category + "|connection " + connectionId + "|" + prepared + "|" + sql;
+    return now + "|" + elapsed + "|" + category + "|connection " + connectionId + "|" + P6Util.singleLine(prepared) + "|" + P6Util.singleLine(sql);
   }
 }

--- a/src/test/java/com/p6spy/engine/common/P6UtilTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6UtilTest.java
@@ -30,7 +30,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class P6UtilTest {
-
+  @Test
+  public void testSingleLine() {
+      Assert.assertEquals("abc efg", P6Util.singleLine("abc\nefg"));
+      Assert.assertEquals("abc efg", P6Util.singleLine("abc\n\nefg"));
+      Assert.assertEquals("abc efg", P6Util.singleLine("abc\r\n\nefg"));
+  }
   @Test 
   public void testJoinNullSafe() {
     Assert.assertEquals("", P6Util.joinNullSafe(null, null));


### PR DESCRIPTION
in SingleLineFormat.java,  replace the prepared and sql which maybe contains CRLF with a blank to make the log really in  a single line. 
