### PR TITLE
Slowdown proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>p6spy</groupId>
   <artifactId>p6spy</artifactId>
   <name>P6Spy</name>
-  <version>2.1.3-SNAPSHOT</version>
+  <version>2.1.3-SLOWDOWN-SNAPSHOT</version>
   <organization>
 	<name>P6Spy</name>
   </organization>

--- a/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
+++ b/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * P6Spy
+ * %%
+ * Copyright (C) 2002 - 2014 P6Spy
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.p6spy.engine.logging;
 
 import com.p6spy.engine.common.P6LogQuery;

--- a/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
+++ b/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
@@ -31,17 +31,12 @@ import org.objectweb.util.monolog.wrapper.p6spy.P6SpyLogger;
 public class P6DelayHandler {
     public static void delay(long startTime, StatementInformation statementInformation) {
         long delay = P6SpyOptions.getActiveInstance().getFixedDelay();
-        if (delay > 0 && ((System.currentTimeMillis() - startTime) < delay)) {
+        if (delay > 0) {
             P6LogQuery.logElapsed(statementInformation.getConnectionId(), startTime, Category.STATEMENT, statementInformation);
-
-            long time = System.currentTimeMillis() - startTime;
-            //Close enough, can't be completely exact
             try {
-                if ((delay - time) > 0) {
-                    Thread.sleep(delay - time);
-                }
+                Thread.sleep(delay);
             } catch(InterruptedException e){
-                    P6LogQuery.error("ERROR");
+                P6LogQuery.error("ERROR");
             }
 
         }

--- a/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
+++ b/src/main/java/com/p6spy/engine/logging/P6DelayHandler.java
@@ -1,0 +1,31 @@
+package com.p6spy.engine.logging;
+
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.common.StatementInformation;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.P6Logger;
+import org.objectweb.util.monolog.wrapper.p6spy.P6SpyLogger;
+
+/**
+ * Created by michaelmainguy on 11/5/14.
+ */
+public class P6DelayHandler {
+    public static void delay(long startTime, StatementInformation statementInformation) {
+        long delay = P6SpyOptions.getActiveInstance().getFixedDelay();
+        if (delay > 0 && ((System.currentTimeMillis() - startTime) < delay)) {
+            P6LogQuery.logElapsed(statementInformation.getConnectionId(), startTime, Category.STATEMENT, statementInformation);
+
+            long time = System.currentTimeMillis() - startTime;
+            //Close enough, can't be completely exact
+            try {
+                if ((delay - time) > 0) {
+                    Thread.sleep(delay - time);
+                }
+            } catch(InterruptedException e){
+                    P6LogQuery.error("ERROR");
+            }
+
+        }
+    }
+
+}

--- a/src/main/java/com/p6spy/engine/logging/P6LogPreparedStatementExecuteDelegate.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogPreparedStatementExecuteDelegate.java
@@ -48,6 +48,7 @@ class P6LogPreparedStatementExecuteDelegate implements Delegate {
       return result;
       
     } finally {
+      P6DelayHandler.delay(startTime, preparedStatementInformation);
       P6LogQuery.logElapsed(preparedStatementInformation.getConnectionId(), startTime, Category.STATEMENT, preparedStatementInformation);
     }
   }

--- a/src/main/java/com/p6spy/engine/logging/P6LogStatementExecuteBatchDelegate.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogStatementExecuteBatchDelegate.java
@@ -41,6 +41,7 @@ class P6LogStatementExecuteBatchDelegate implements Delegate {
       return method.invoke(underlying, args);
     }
     finally {
+
       P6LogQuery.logElapsed(statementInformation.getConnectionId(), startTime, Category.STATEMENT, statementInformation);
     }
   }

--- a/src/main/java/com/p6spy/engine/logging/P6LogStatementExecuteDelegate.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogStatementExecuteDelegate.java
@@ -23,6 +23,8 @@ import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.proxy.Delegate;
 import com.p6spy.engine.proxy.ProxyFactory;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.P6Logger;
 
 import java.lang.reflect.Method;
 import java.sql.ResultSet;
@@ -48,7 +50,9 @@ class P6LogStatementExecuteDelegate implements Delegate {
       return result;
     }
     finally {
+      P6DelayHandler.delay(startTime, statementInformation);
       P6LogQuery.logElapsed(statementInformation.getConnectionId(), startTime, Category.STATEMENT, statementInformation);
+
     }
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/P6SpyLoadableOptions.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyLoadableOptions.java
@@ -43,4 +43,7 @@ public interface P6SpyLoadableOptions extends P6LoadableOptions, P6SpyOptionsMBe
   MessageFormattingStrategy getLogMessageFormatInstance();
   
   void setJmx(String jmx);
+  long getFixedDelay();
+
+  void setFixedDelay(String FixedDelay);
 }

--- a/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
@@ -56,6 +56,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
     public static final String DATABASE_DIALECT_DATE_FORMAT = "databaseDialectDateFormat";
     public static final String JMX = "jmx";
     public static final String JMX_PREFIX = "jmxPrefix";
+    public static final String FIXED_DELAY = "fixedDelay";
     
     // those set indirectly (via properties visible from outside)
     public static final String DRIVER_NAMES = "driverNames";
@@ -79,6 +80,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       defaults.put(RELOADPROPERTIESINTERVAL, Long.toString(60));
       defaults.put(DATABASE_DIALECT_DATE_FORMAT, "dd-MMM-yy");
       defaults.put(JMX, Boolean.TRUE.toString());
+      defaults.put(FIXED_DELAY, Long.toString(0));
     }
 
     private final P6OptionsRepository optionsRepository;
@@ -111,6 +113,9 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       setDatabaseDialectDateFormat(options.get(DATABASE_DIALECT_DATE_FORMAT));
       setJmx(options.get(JMX));
       setJmxPrefix(options.get(JMX_PREFIX));
+      setFixedDelay(options.get(FIXED_DELAY));
+
+
     }
     
     /**
@@ -426,6 +431,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       return optionsRepository.get(Boolean.class, JMX);
     }
 
+
     @Override
     public void setJmx(String string) {
       optionsRepository.set(Boolean.class, JMX, string);
@@ -445,4 +451,10 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
     public void setJmxPrefix(String jmxPrefix) {
       optionsRepository.set(String.class, JMX_PREFIX, jmxPrefix);
     }
+
+    @Override
+    public void setFixedDelay(String fixedDelay) { optionsRepository.set(Long.class, FIXED_DELAY, fixedDelay);}
+
+    @Override
+    public long getFixedDelay() {return optionsRepository.get(Long.class, FIXED_DELAY);}
 }

--- a/src/main/java/com/p6spy/engine/spy/option/SpyDotPropertiesReloader.java
+++ b/src/main/java/com/p6spy/engine/spy/option/SpyDotPropertiesReloader.java
@@ -94,6 +94,9 @@ public class SpyDotPropertiesReloader implements P6OptionChangedListener {
       reschedule(Boolean.valueOf(newValue.toString()), P6SpyOptions.getActiveInstance().getReloadPropertiesInterval());
     } else if (key.equals(P6SpyOptions.RELOADPROPERTIESINTERVAL)) {
       reschedule(P6SpyOptions.getActiveInstance().getReloadProperties(), (Long) newValue);
+    } else if (key.equals(P6SpyOptions.FIXED_DELAY)) {
+        reschedule(P6SpyOptions.getActiveInstance().getReloadProperties(),(Long)newValue);
+
     }
   }
 

--- a/src/site/markdown/2.0/configandusage.md
+++ b/src/site/markdown/2.0/configandusage.md
@@ -274,6 +274,15 @@ in section: [Configuration and Usage](#confusage)):
     #outagedetection=false
     # (default is 60)
     #outagedetectioninterval=30
+    #
+    # Statement execution delay
+    #
+    # This allows you to arbitrary slow down processing of statements by a fixed amount of time.
+    # It can be used to detect problems caused by database slowdowns.
+    #
+    #fixedDelay=500
+    #(Slow down each statement by an additional 500ms
+    #
     
 ### modulelist
 

--- a/src/test/java/com/p6spy/engine/spy/P6TestPreparedStatement.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestPreparedStatement.java
@@ -94,7 +94,26 @@ public class P6TestPreparedStatement extends P6TestFramework {
       fail(e.getMessage() + " due to error:\n" + getStackTrace(e));
     }
   }
-  
+
+    @Test
+    public void testExecuteDelayed() {
+        try {
+            // insert test data
+            P6SpyOptions.getActiveInstance().setFixedDelay("5000");
+            String sql = "select x from system_range(?,?)";
+            PreparedStatement prep = getPreparedStatement(sql);
+            prep.setInt(1, 1);
+            prep.setInt(2, 1);
+            super.clearLogEntries();
+            ResultSet rs = prep.executeQuery();
+            assertEquals(2,super.getLogEntries().size());
+
+            rs.close();
+            prep.close();
+        } catch (Exception e) {
+            fail(e.getMessage() + " due to error:\n" + getStackTrace(e));
+        }
+    }
   @Test
   public void testSameColumnNameInMultipleTables() throws SQLException {
     try {
@@ -115,19 +134,19 @@ public class P6TestPreparedStatement extends P6TestFramework {
           prep.executeUpdate();
           prep.close();
         }
-  
+
         super.clearLogEntries();
-  
+
         // let's check that returned data are reported correctly
         // => don't filter 'result' and 'resultset'
         P6LogOptions.getActiveInstance().setExcludecategories("");
-  
+
         final String query = "select prepstmt_test.col1, prepstmt_test2.col1, prepstmt_test.col2, prepstmt_test2.col2 from prepstmt_test, prepstmt_test2 where prepstmt_test.col2 = prepstmt_test2.col2 and prepstmt_test.col1 = ? and prepstmt_test2.col1 = ?";
         final PreparedStatement prep = getPreparedStatement(query);
         prep.setString(1, "prepstmt_test_col1");
         prep.setString(2, "prepstmt_test_col2");
         final ResultSet rs = prep.executeQuery();
-  
+
         // check "statement" logged properly
         assertNotNull(super.getLastLogEntry());
         assertTrue("prepared statement not logged properly",
@@ -138,7 +157,7 @@ public class P6TestPreparedStatement extends P6TestFramework {
             super.getLastLogEntry().contains(
                 query.replaceFirst("\\?", "\'prepstmt_test_col1\'").replaceFirst("\\?",
                     "\'prepstmt_test_col2\'")));
-  
+
         // check returned (real) data not messed up
         while (rs.next()) {
           assertEquals("returned values messed up", "prepstmt_test_col1", rs.getString(1));
@@ -148,7 +167,7 @@ public class P6TestPreparedStatement extends P6TestFramework {
         }
         rs.close();
         prep.close();
-  
+
         // check "resultset" logged properly
         assertNotNull(super.getLastLogEntry());
         assertTrue("resultset not logged", super.getLastLogEntry().contains("resultset"));
@@ -156,9 +175,9 @@ public class P6TestPreparedStatement extends P6TestFramework {
             "logged resultset holds incorrect values",
             super.getLastLogEntry().endsWith(
                 "1 = prepstmt_test_col1, 2 = prepstmt_test_col2, 3 = 1, 4 = 1"));
-  
+
         P6LogOptions.getActiveInstance().setExcludecategories("result,resultset");
-      
+
     } catch (Exception e) {
       fail(e.getMessage() + " due to error:\n" + getStackTrace(e));
     }
@@ -189,13 +208,13 @@ public class P6TestPreparedStatement extends P6TestFramework {
         bigSelect.append(" col2=?");
       }
       prep.close();
-      
+
       prep = getPreparedStatement(bigSelect.toString());
       for (int i = 1; i <= MaxFields; i++) {
         prep.setInt(i, i);
       }
       prep.close();
-      
+
       // test batch inserts
       update = "insert into prepstmt_test values (?,?)";
       prep = getPreparedStatement(update);
@@ -213,20 +232,20 @@ public class P6TestPreparedStatement extends P6TestFramework {
       assertTrue(super.getLastLogEntry().contains("aspen"));
       assertTrue(super.getLastLogEntry().contains("4"));
       prep.close();
-      
+
       String query = "select count(*) from prepstmt_test";
       prep = getPreparedStatement(query);
       ResultSet rs = prep.executeQuery();
       rs.next();
       assertEquals(4, rs.getInt(1));
-      
+
       rs.close();
       prep.close();
     } catch (Exception e) {
       fail(e.getMessage() + " due to error:\n" + getStackTrace(e));
     }
   }
-  
+
   @Test
   public void testCallingSetMethodsOnStatementInterface() throws SQLException {
     String sql = "select * from prepstmt_test where col1 = ?";
@@ -234,11 +253,11 @@ public class P6TestPreparedStatement extends P6TestFramework {
 
     prep.setMaxRows(1);
     assertEquals(1, prep.getMaxRows());
-    
+
     prep.setQueryTimeout(12);
     // The SQLLite driver returns the value in ms
     assertEquals(("SQLite".equals(db) ? 12000 : 12), prep.getQueryTimeout());
-    
+
     prep.close();
   }
 
@@ -258,7 +277,7 @@ public class P6TestPreparedStatement extends P6TestFramework {
     try {
       Statement statement = connection.createStatement();
       dropPrepared(statement);
-      statement.close();  
+      statement.close();
     } catch (Exception e) {
       fail(e.getMessage() + " due to error:\n" + getStackTrace(e));
     }

--- a/src/test/java/com/p6spy/engine/spy/P6TestStatement.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestStatement.java
@@ -172,4 +172,30 @@ public class P6TestStatement extends P6TestFramework {
     }
   }
 
+    @Test
+    public void testFixedDelayed() throws SQLException {
+        Statement statement = connection.createStatement();
+
+        try {
+            // set the execution threshold very low
+            P6SpyOptions.getActiveInstance().setFixedDelay("5000");
+
+            // test a basic select
+            String query = "select x from system_range(1,1)";
+            ResultSet rs = statement.executeQuery(query);
+            assertEquals(2,super.getLogEntries().size());
+            assertTrue(super.getLastLogEntry().contains(query));
+            // finally just make sure the query executed!
+            rs.next();
+            assertEquals(1, rs.getInt(1));
+            rs.close();
+
+
+        } finally {
+            if (statement != null) {
+                statement.close();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Added code to allow a new spy.properties parameter called "fixedDelay" that blocks the thread for a fixed amount of time to simulate a database slowdown.