### PR TITLE
introduced TinyLog (tinylog.org) Logger support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,13 @@
 	  <scope>provided</scope>
 	 </dependency>
 	 
+	 <dependency>
+	  <groupId>org.tinylog</groupId>
+	  <artifactId>tinylog</artifactId>
+	  <version>1.0-rc-1</version>
+	  <scope>provided</scope>
+	</dependency>
+	
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>

--- a/src/main/assembly/individualFiles/spy.properties
+++ b/src/main/assembly/individualFiles/spy.properties
@@ -84,6 +84,7 @@
 #appender=com.p6spy.engine.spy.appender.Slf4JLogger
 #appender=com.p6spy.engine.spy.appender.StdoutLogger
 #appender=com.p6spy.engine.spy.appender.FileLogger
+#appender=com.p6spy.engine.spy.appender.TinyLogLogger
 
 # name of logfile to use, note Windows users should make sure to use forward slashes in their pathname (e:/test/spy.log) 
 # (used for com.p6spy.engine.spy.appender.FileLogger only)

--- a/src/main/java/com/p6spy/engine/spy/appender/TinyLogLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/TinyLogLogger.java
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * P6Spy
+ * %%
+ * Copyright (C) 2002 - 2014 P6Spy
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.p6spy.engine.spy.appender;
+
+import org.pmw.tinylog.Logger;
+
+import com.p6spy.engine.logging.Category;
+
+/**
+ * TinyLog (http://www.tinylog.org/) logger implementation.
+ * 
+ * (as seen on: http://www.heise.de/developer/meldung/Java-Logger-tinylog-ist-Feature-Complete-2459393.html?wt_mc=rss.developer.beitrag.atom)
+ * 
+ * @see <a href="http://www.tinylog.org/">http://www.tinylog.org/</a>
+ * @author peterb
+ */
+public class TinyLogLogger extends FormattedLogger {
+  
+  @Override
+  public void logException(Exception e) {
+    Logger.info(e);
+  }
+
+  @Override
+  public void logText(String text) {
+    Logger.info(text);
+  }
+
+  @Override
+  public void logSQL(int connectionId, String now, long elapsed,
+      Category category, String prepared, String sql) {
+    final String msg = strategy.formatMessage(connectionId, now, elapsed,
+        category.toString(), prepared, sql);
+
+    if (Category.ERROR.equals(category)) {
+      Logger.error(msg);
+    } else if (Category.WARN.equals(category)) {
+      Logger.warn(msg);
+    } else if (Category.DEBUG.equals(category)) {
+      Logger.debug(msg);
+    } else {
+      Logger.info(msg);
+    }
+  }
+
+  @Override
+  public boolean isCategoryEnabled(Category category) {
+    // didn't see any option for filtering
+    return true;
+  }
+}

--- a/src/site/markdown/2.0/configandusage.md
+++ b/src/site/markdown/2.0/configandusage.md
@@ -122,6 +122,7 @@ in section: [Configuration and Usage](#confusage)):
     #appender=com.p6spy.engine.spy.appender.Slf4JLogger
     #appender=com.p6spy.engine.spy.appender.StdoutLogger
     #appender=com.p6spy.engine.spy.appender.FileLogger
+    #appender=com.p6spy.engine.spy.appender.TinyLogLogger
 
     # name of logfile to use, note Windows users should make sure to use forward slashes in their pathname (e:/test/spy.log) 
     # (used for com.p6spy.engine.spy.appender.FileLogger only)
@@ -349,6 +350,7 @@ and logging to a file (default). Please note, that all of these output in the CS
         #appender=com.p6spy.engine.spy.appender.Slf4JLogger
         #appender=com.p6spy.engine.spy.appender.StdoutLogger
         appender=com.p6spy.engine.spy.appender.FileLogger
+        #appender=com.p6spy.engine.spy.appender.TinyLogLogger
 
         # name of logfile to use, note Windows users should make sure to use forward slashes in their pathname (e:/test/spy.log) 
 	    # (used for com.p6spy.engine.spy.appender.FileLogger only)
@@ -364,12 +366,14 @@ and logging to a file (default). Please note, that all of these output in the CS
         #appender=com.p6spy.engine.spy.appender.Slf4JLogger
         appender=com.p6spy.engine.spy.appender.StdoutLogger
         #appender=com.p6spy.engine.spy.appender.FileLogger
+        #appender=com.p6spy.engine.spy.appender.TinyLogLogger
 
 * **Using SLF4J**: Uncomment the `Slf4JLogger` as follows:
 
         appender=com.p6spy.engine.spy.appender.Slf4JLogger
         #appender=com.p6spy.engine.spy.appender.StdoutLogger
         #appender=com.p6spy.engine.spy.appender.FileLogger
+        #appender=com.p6spy.engine.spy.appender.TinyLogLogger
 
 	In general you need to slf4j-api and the appropriate bridge to the actual logging
 implementation as well as the logging implementation itself on your classpath. To simplify setup for those not having any of the additional dependencies already
@@ -396,6 +400,27 @@ on classpath following `*-nodep.jar` bundles are provided as part of p6spy distr
           </category>
 	
 	For further instructions on configuring SLF4J, see the [SLF4J documentation](http://www.slf4j.org/manual.html).
+	
+* **Using TinyLog**: Uncomment the `TinyLogLogger` as follows:
+
+        #appender=com.p6spy.engine.spy.appender.Slf4JLogger
+        #appender=com.p6spy.engine.spy.appender.StdoutLogger
+        #appender=com.p6spy.engine.spy.appender.FileLogger
+        appender=com.p6spy.engine.spy.appender.TinyLogLogger
+
+	You'll need to include [TinyLog](http://www.tinylog.org/) on your classpath.
+	  
+    Mapping to TinyLog levels is provided in the following way:
+    
+	<table>
+	<tr><th>P6Spy category</th><th>TinyLog level</th></tr>
+	<tr><td>error</td><td>error</td></tr>
+	<tr><td>warn</td><td>warning</td></tr>
+	<tr><td>debug</td><td>debug</td></tr>
+	<tr><td>info/any other category</td><td>info</td></tr>
+	</table>	
+	
+	For further instructions on configuring SLF4J, see the [TinyLog documentation](http://www.tinylog.org/).
 
 ### logMessageFormat
 

--- a/src/test/java/com/p6spy/engine/spy/appender/TinyLogLoggerTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/TinyLogLoggerTest.java
@@ -1,0 +1,141 @@
+/*
+ * #%L
+ * P6Spy
+ * %%
+ * Copyright (C) 2002 - 2014 P6Spy
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.p6spy.engine.spy.appender;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.LogManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pmw.tinylog.Configurator;
+import org.pmw.tinylog.Level;
+import org.pmw.tinylog.writers.FileWriter;
+
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.logging.P6LogOptions;
+import com.p6spy.engine.test.BaseTestCase;
+import com.p6spy.engine.test.P6TestFramework;
+
+public class TinyLogLoggerTest extends BaseTestCase {
+
+  private static final File SPY_TINYLOG_FILE = new File("target", "spy.tinylog.log");
+  
+  private P6TestFramework framework;
+
+  @Before
+  public void setup() throws Exception {
+    // reset log4j
+    LogManager.resetConfiguration();
+
+    // initialize framework
+    framework = new P6TestFramework("tinylog") {
+    };
+    framework.setUpFramework();
+  }
+  
+  @After
+  public void cleanUp() {
+    // not sure, how they do proper cleanup, but who cares?
+    Configurator.defaultConfig().removeAllWriters();
+    
+    if (SPY_TINYLOG_FILE.exists()) {
+      SPY_TINYLOG_FILE.delete();
+    }
+  }
+
+  @Test
+  public void testCategoryToLevelMapping() throws Exception {
+
+    checkCategoryToLevelMapping(Category.ERROR, null, Level.OFF);
+    checkCategoryToLevelMapping(Category.ERROR, Level.ERROR, Level.ERROR);
+    checkCategoryToLevelMapping(Category.ERROR, Level.ERROR, Level.WARNING);
+    checkCategoryToLevelMapping(Category.ERROR, Level.ERROR, Level.INFO);
+    checkCategoryToLevelMapping(Category.ERROR, Level.ERROR, Level.DEBUG);
+
+    checkCategoryToLevelMapping(Category.WARN, null, Level.OFF);
+    checkCategoryToLevelMapping(Category.WARN, null, Level.ERROR);
+    checkCategoryToLevelMapping(Category.WARN, Level.WARNING, Level.WARNING);
+    checkCategoryToLevelMapping(Category.WARN, Level.WARNING, Level.INFO);
+    checkCategoryToLevelMapping(Category.WARN, Level.WARNING, Level.DEBUG);
+
+    checkCategoryToInfoLevelMapping(Category.INFO);
+
+    checkCategoryToLevelMapping(Category.DEBUG, null, Level.OFF);
+    checkCategoryToLevelMapping(Category.DEBUG, null, Level.ERROR);
+    checkCategoryToLevelMapping(Category.DEBUG, null, Level.WARNING);
+    checkCategoryToLevelMapping(Category.DEBUG, null, Level.INFO);
+    checkCategoryToLevelMapping(Category.DEBUG, Level.DEBUG, Level.DEBUG);
+
+    checkCategoryToInfoLevelMapping(Category.BATCH);
+    checkCategoryToInfoLevelMapping(Category.STATEMENT);
+    checkCategoryToInfoLevelMapping(Category.RESULTSET);
+    checkCategoryToInfoLevelMapping(Category.COMMIT);
+    checkCategoryToInfoLevelMapping(Category.ROLLBACK);
+    checkCategoryToInfoLevelMapping(Category.RESULT);
+    checkCategoryToInfoLevelMapping(Category.OUTAGE);
+
+    checkCategoryToInfoLevelMapping(new Category("newly_created_category"));
+  }
+
+  private void checkCategoryToInfoLevelMapping(Category category) throws Exception {
+    checkCategoryToLevelMapping(category, null, Level.OFF);
+    checkCategoryToLevelMapping(category, null, Level.ERROR);
+    checkCategoryToLevelMapping(category, null, Level.WARNING);
+    checkCategoryToLevelMapping(category, Level.INFO, Level.INFO);
+    checkCategoryToLevelMapping(category, Level.INFO, Level.DEBUG);
+  }
+
+  public void checkCategoryToLevelMapping(Category category, Level expectedLevel,
+                                          Level thresholdLevel) throws Exception {
+    cleanUp();
+    configure(thresholdLevel, true);
+
+    P6LogQuery.log(category, "sample msg", "sample msg");
+
+    List<String> fileLines = FileUtils.readLines(SPY_TINYLOG_FILE);
+    
+    if (expectedLevel == null) {
+      assertEquals(0, fileLines.size());
+    } else {
+      assertEquals(2 /* as they log 2 lines per msg */, fileLines.size());
+      assertTrue(fileLines.get(0).contains("[main] com.p6spy.engine.spy.appender.TinyLogLogger.logSQL()"));
+      assertTrue(fileLines.get(1).contains("sample msg|sample msg"));
+    }
+  }
+
+  protected void configure(Level thresholdLevel, boolean removeDefaultExcludedCategories)
+      throws Exception {
+
+    if (removeDefaultExcludedCategories) {
+      // we test tinylog filtering here rather than categories one
+      P6LogOptions.getActiveInstance().setExcludecategories("");
+    }
+    Configurator.defaultConfig().writer(new FileWriter(SPY_TINYLOG_FILE.getAbsolutePath())).level(thresholdLevel)
+        .activate();
+  }
+  
+}

--- a/src/test/resources/com/p6spy/engine/spy/P6Test_tinylog.properties
+++ b/src/test/resources/com/p6spy/engine/spy/P6Test_tinylog.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# P6Spy
+# %%
+# Copyright (C) 2002 - 2013 P6Spy
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+modulelist=com.p6spy.engine.logging.P6LogFactory,com.p6spy.engine.test.P6TestFactory
+appender=com.p6spy.engine.spy.appender.TinyLogLogger
+
+url=jdbc:p6spy:h2:mem:p6spy
+user=sa
+password=


### PR DESCRIPTION
I read just today about this one (http://www.heise.de/developer/meldung/Java-Logger-tinylog-ist-Feature-Complete-2459393.html?wt_mc=rss.developer.beitrag.atom). 
Seems fast and super-simple. 

So how about having it in p6spy supported without multiple bridges (slf4j -> log4j -> tinylog)? As that would kill performance I think.
