### PR TITLE
Unsafe iteration over System.getProperties()

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/option/SystemProperties.java
+++ b/src/main/java/com/p6spy/engine/spy/option/SystemProperties.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
 
 import com.p6spy.engine.spy.P6ModuleManager;
 

--- a/src/main/java/com/p6spy/engine/spy/option/SystemProperties.java
+++ b/src/main/java/com/p6spy/engine/spy/option/SystemProperties.java
@@ -20,6 +20,7 @@
 package com.p6spy.engine.spy.option;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -33,7 +34,7 @@ public class SystemProperties implements P6OptionsSource {
   public Map<String, String> getOptions() {
     final Map<String, String> result = new HashMap<String, String>();
 
-    for (Entry<Object, Object> entry : System.getProperties().entrySet()) {
+    for (Entry<Object, Object> entry : new HashSet<Entry>(((Properties) System.getProperties().clone()).entrySet())) {
       final String key = entry.getKey().toString();
       if (key.startsWith(P6SPY_PREFIX)) {
         result.put(key.substring(P6SPY_PREFIX.length()), (String) entry.getValue());


### PR DESCRIPTION
Iterating over `System.getProperties().entrySet()` can lead to a `ConcurrentModificationException`. This is happening to a stagemonitor user: https://github.com/stagemonitor/stagemonitor/issues/136

This fix does it the way liquibase tackled it: https://liquibase.jira.com/browse/CORE-2104 https://github.com/liquibase/liquibase/commit/0c42dcd9fe89cbcd82594fc3bb6cfbf2ddbf1104