### PR TITLE
Update CGLIB to 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -501,7 +501,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>2.2.2</version>
+      <version>3.2.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This is a quick fix for #325 as the new version of CGLIB can handle concurrent requests better where the old version would cause a deadlock.