### PR TITLE
vagrant works again (chef cookbooks versions frozen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,9 @@ dependency-reduced-pom.xml
 .vagrant
 Berksfile.lock
 
-# bitronix transaction logs
+# bitronix transaction stuff
 btm*.tlog
+p6spy_xds
 
 # hsql
 mem.h2.db

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,8 @@
-source "https://supermarket.getchef.com"
+source 'https://supermarket.getchef.com'
 
-cookbook "java"
-cookbook "postgresql"
-cookbook "mysql"
-cookbook "sqlite"
-cookbook "maven"
-cookbook "groovy"
+cookbook 'java',       '= 1.29.0'
+cookbook 'postgresql', '= 3.4.12'
+cookbook 'mysql',      '= 5.6.3'
+cookbook 'sqlite',     '= 1.1.0'
+cookbook 'maven',      '= 1.2.0'
+cookbook 'groovy',     '= 0.0.1'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,7 +175,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		  "server_debian_password" => "123" 
 	  },
 		  # groovy
-		  "groovy" => { "version" => "2.1.9" }
+		  "groovy" => {
+        "version"  => "2.1.9",
+        "url"      => "https://dl.bintray.com/groovy/maven/groovy-binary-2.1.9.zip",
+        "checksum" => "d9cb8d54680d508ac1eb928f8d0cfb1fb1bec7843bb405ea9a7d18f512b10ba6"
+      }
 	  }
   end
 


### PR DESCRIPTION
well, it's been a while since someone ran these, due to #326 I've been playing around with it again.
At least we have it running now (even with older chef cookbook versions).
In fact to reproduce integration (travis) environment locally, we'd probably need dockerized approach (which was not available in travis back then), however it can still serve it's purpose these days. 