### PR TITLE
Fixes NPE on static initializer order

### DIFF
--- a/src/main/java/com/p6spy/engine/common/P6LogQuery.java
+++ b/src/main/java/com/p6spy/engine/common/P6LogQuery.java
@@ -43,18 +43,17 @@ public class P6LogQuery implements P6OptionChangedListener {
   
   private static final Set<Category> CATEGORIES_IMPLICITLY_INCLUDED = new HashSet<Category>(
 	      Arrays.asList(Category.ERROR, Category.OUTAGE /* we still want to have outage category enabled! */));
-  
+  /**
+   * Options that cause re-init of {@link P6LogQuery}.
+   */
+  private static final Set<String> ON_CHANGE = new HashSet<String>(Arrays.asList(
+    P6SpyOptions.APPENDER_INSTANCE, P6SpyOptions.LOGFILE, P6SpyOptions.LOG_MESSAGE_FORMAT_INSTANCE));
+
   protected static P6Logger logger;
 
   static {
     initialize();
   }
-
-  /**
-   * Options that cause re-init of {@link P6LogQuery}.
-   */
-  private static final Set<String> ON_CHANGE = new HashSet<String>(Arrays.asList(
-      P6SpyOptions.APPENDER_INSTANCE, P6SpyOptions.LOGFILE, P6SpyOptions.LOG_MESSAGE_FORMAT_INSTANCE));
 
   public void optionChanged(final String key, final Object oldValue, final Object newValue) {
     if (ON_CHANGE.contains(key)) {


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException: null
	at com.p6spy.engine.common.P6LogQuery.optionChanged(P6LogQuery.java:60)
```