### PR TITLE
fix: register passthru drivers on P6SpyDriver init (closes #348)

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -42,9 +42,6 @@ public class P6SpyDriver implements Driver {
   static {
     try {
       DriverManager.registerDriver(INSTANCE);
-      
-      // registers the passthru drivers, if configured s
-  	  P6ModuleManager.getInstance();
     } catch (SQLException e) {
       throw new IllegalStateException("Could not register P6SpyDriver with DriverManager", e);
     }
@@ -103,6 +100,9 @@ public class P6SpyDriver implements Driver {
   }
 
   protected Driver findPassthru(String url) throws SQLException {
+    // registers the passthru drivers, if configured s
+    P6ModuleManager.getInstance();
+    
     String realUrl = extractRealUrl(url);
     Driver passthru = null;
     for (Driver driver: registeredDrivers() ) {

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -42,6 +42,9 @@ public class P6SpyDriver implements Driver {
   static {
     try {
       DriverManager.registerDriver(INSTANCE);
+      
+      // registers the passthru drivers, if configured s
+  	  P6ModuleManager.getInstance();
     } catch (SQLException e) {
       throw new IllegalStateException("Could not register P6SpyDriver with DriverManager", e);
     }


### PR DESCRIPTION
I tested it locally, not sure about further impact.

We'd have public evidence for fix however only once this gets to release (rc3 maybe) and p6spy-it re-runs