### PR TITLE
[RFC] chore: proper snapshot version (3.0.0-rc3-SNAPSHOT)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>p6spy</groupId>
   <artifactId>p6spy</artifactId>
   <name>P6Spy</name>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0-rc3-SNAPSHOT</version>
   <organization>
     <name>P6Spy</name>
   </organization>


### PR DESCRIPTION
as stated in the discussion of: #350, let's use the proper snapshot version