### PR TITLE
fix: install apt-fast ignoring keys

### DIFF
--- a/script/travis/before_install_apt-fast.sh
+++ b/script/travis/before_install_apt-fast.sh
@@ -5,4 +5,4 @@
 
 sudo add-apt-repository -y ppa:apt-fast/stable
 sudo apt-get update -qq -y
-sudo apt-get install -qq -y apt-fast
+sudo apt-get install -qq -y --force-yes apt-fast


### PR DESCRIPTION
let's try to workaround failing job: https://travis-ci.org/p6spy/p6spy/jobs/162807866