### PR TITLE
Store the creator of a connection and the connection itself in ConnectionInformation

### DIFF
--- a/src/main/java/com/p6spy/engine/common/ConnectionInformation.java
+++ b/src/main/java/com/p6spy/engine/common/ConnectionInformation.java
@@ -19,7 +19,12 @@
  */
 package com.p6spy.engine.common;
 
+import java.sql.Connection;
+import java.sql.Driver;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.sql.CommonDataSource;
+import javax.sql.PooledConnection;
 
 /**
  * @author Quinton McCombs
@@ -29,9 +34,77 @@ public class ConnectionInformation implements Loggable {
 
   private static final AtomicInteger counter = new AtomicInteger(0);
   private final int connectionId;
+  private CommonDataSource dataSource;
+  private Driver driver;
+  private Connection connection;
+  private PooledConnection pooledConnection;
+  private long timeToGetConnectionNs;
 
-  public ConnectionInformation() {
+  private ConnectionInformation() {
     this.connectionId = counter.getAndIncrement();
+  }
+
+  /**
+   * Creates a new {@link ConnectionInformation} instance for a {@link Connection} which has been obtained via a
+   * {@link Driver}
+   *
+   * @param driver                the {@link Driver} which created the {@link #connection}
+   * @param connection            the {@link #connection} created by the {@link #driver}
+   * @param timeToGetConnectionNs the time it took to obtain the connection in nanoseconds
+   * @return a new {@link ConnectionInformation} instance
+   */
+  public static ConnectionInformation fromDriver(Driver driver, Connection connection, long timeToGetConnectionNs) {
+    final ConnectionInformation connectionInformation = new ConnectionInformation();
+    connectionInformation.driver = driver;
+    connectionInformation.connection = connection;
+    connectionInformation.timeToGetConnectionNs = timeToGetConnectionNs;
+    return connectionInformation;
+  }
+
+  /**
+   * Creates a new {@link ConnectionInformation} instance for a {@link Connection} which has been obtained via a
+   * {@link CommonDataSource}
+   *
+   * @param dataSource            the {@link javax.sql.CommonDataSource} which created the {@link #connection}
+   * @param connection            the {@link #connection} created by the {@link #dataSource}
+   * @param timeToGetConnectionNs the time it took to obtain the connection in nanoseconds
+   * @return a new {@link ConnectionInformation} instance
+   */
+  public static ConnectionInformation fromDataSource(CommonDataSource dataSource, Connection connection, long timeToGetConnectionNs) {
+    final ConnectionInformation connectionInformation = new ConnectionInformation();
+    connectionInformation.dataSource = dataSource;
+    connectionInformation.connection = connection;
+    connectionInformation.timeToGetConnectionNs = timeToGetConnectionNs;
+    return connectionInformation;
+  }
+
+  /**
+   * Creates a new {@link ConnectionInformation} instance for a {@link Connection} which has been obtained via a
+   * {@link PooledConnection}
+   *
+   * @param pooledConnection      the {@link PooledConnection} which created the {@link #connection}
+   * @param connection            the {@link #connection} created by the {@link #pooledConnection}
+   * @param timeToGetConnectionNs the time it took to obtain the connection in nanoseconds
+   * @return a new {@link ConnectionInformation} instance
+   */
+  public static ConnectionInformation fromPooledConnection(PooledConnection pooledConnection, Connection connection, long timeToGetConnectionNs) {
+    final ConnectionInformation connectionInformation = new ConnectionInformation();
+    connectionInformation.pooledConnection = pooledConnection;
+    connectionInformation.connection = connection;
+    connectionInformation.timeToGetConnectionNs = timeToGetConnectionNs;
+    return connectionInformation;
+  }
+
+  /**
+   * This method should only be used in test scenarios
+   *
+   * @param connection the underlying connection (possibly a mock)
+   * @return a new {@link ConnectionInformation} instance
+   */
+  public static ConnectionInformation fromTestConnection(Connection connection) {
+    final ConnectionInformation connectionInformation = new ConnectionInformation();
+    connectionInformation.connection = connection;
+    return connectionInformation;
   }
 
   @Override
@@ -47,5 +120,53 @@ public class ConnectionInformation implements Loggable {
   @Override
   public String getSqlWithValues() {
     return "";
+  }
+
+  /**
+   * Returns the {@link #dataSource} which created the {@link #connection}
+   * or <code>null</code> if it wasn't created via a {@link CommonDataSource}.
+   *
+   * @return the {@link #dataSource} which created the {@link #connection}
+   */
+  public CommonDataSource getDataSource() {
+    return dataSource;
+  }
+
+  /**
+   * Returns the {@link #driver} which created the {@link #connection}
+   * or <code>null</code> if it wasn't created via a {@link Driver}.
+   *
+   * @return the {@link #driver} which created the {@link #connection}
+   */
+  public Driver getDriver() {
+    return driver;
+  }
+
+  /**
+   * Returns a reference to the {@link Connection}
+   *
+   * @return a reference to the {@link Connection}
+   */
+  public Connection getConnection() {
+    return connection;
+  }
+
+  /**
+   * Returns the {@link #pooledConnection} which created the {@link #connection}
+   * or <code>null</code> if it wasn't created via a {@link PooledConnection}.
+   *
+   * @return the {@link #pooledConnection} which created the {@link #connection}
+   */
+  public PooledConnection getPooledConnection() {
+    return pooledConnection;
+  }
+
+  /**
+   * Returns the time it took to obtain the connection in nanoseconds
+   *
+   * @return the time it took to obtain the connection in nanoseconds
+   */
+  public long getTimeToGetConnectionNs() {
+    return timeToGetConnectionNs;
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -19,6 +19,7 @@
  */
 package com.p6spy.engine.spy;
 
+import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.CompoundJdbcEventListener;
 import com.p6spy.engine.event.DefaultEventListener;
 import com.p6spy.engine.event.JdbcEventListener;
@@ -38,12 +39,15 @@ public class P6Core {
 
   private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = ServiceLoader.load(JdbcEventListener.class, P6Core.class.getClassLoader());
 
-  public static Connection wrapConnection(Connection realConnection) {
+  public static Connection wrapConnection(Connection realConnection, ConnectionInformation connectionInformation) {
+    if (realConnection == null) {
+      return null;
+    }
     final CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
     compoundEventListener.addListender(DefaultEventListener.INSTANCE);
     registerEventListenersFromFactories(compoundEventListener);
     registerEventListenersFromServiceLoader(compoundEventListener);
-    return ConnectionWrapper.wrap(realConnection, compoundEventListener);
+    return ConnectionWrapper.wrap(realConnection, compoundEventListener, connectionInformation);
   }
 
   private static void registerEventListenersFromFactories(CompoundJdbcEventListener compoundEventListener) {

--- a/src/main/java/com/p6spy/engine/spy/P6DataSource.java
+++ b/src/main/java/com/p6spy/engine/spy/P6DataSource.java
@@ -19,6 +19,7 @@
  */
 package com.p6spy.engine.spy;
 
+import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.P6LogQuery;
 
 import javax.naming.Context;
@@ -283,7 +284,9 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     if (realDataSource == null) {
       bindDataSource();
     }
-    return P6Core.wrapConnection(((DataSource) realDataSource).getConnection());
+    final long start = System.nanoTime();
+    final Connection connection = ((DataSource) realDataSource).getConnection();
+    return P6Core.wrapConnection(connection, ConnectionInformation.fromDataSource(realDataSource, connection, System.nanoTime() - start));
   }
 
   @Override
@@ -291,7 +294,9 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     if (realDataSource == null) {
       bindDataSource();
     }
-    return P6Core.wrapConnection(((DataSource) realDataSource).getConnection(username, password));
+    final long start = System.nanoTime();
+    final Connection connection = ((DataSource) realDataSource).getConnection(username, password);
+    return P6Core.wrapConnection(connection, ConnectionInformation.fromDataSource(realDataSource, connection, System.nanoTime() - start));
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
+++ b/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
@@ -19,12 +19,14 @@
  */
 package com.p6spy.engine.spy;
 
-import javax.sql.ConnectionEventListener;
-import javax.sql.PooledConnection;
-import javax.sql.StatementEventListener;
+import com.p6spy.engine.common.ConnectionInformation;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import javax.sql.ConnectionEventListener;
+import javax.sql.PooledConnection;
+import javax.sql.StatementEventListener;
 
 public class P6PooledConnection implements PooledConnection {
 
@@ -36,7 +38,9 @@ public class P6PooledConnection implements PooledConnection {
 
   @Override
   public Connection getConnection() throws SQLException {
-    return P6Core.wrapConnection(passthru.getConnection());
+    long start = System.nanoTime();
+    final Connection connection = passthru.getConnection();
+    return P6Core.wrapConnection(connection, ConnectionInformation.fromPooledConnection(passthru, connection, System.nanoTime() - start));
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -19,6 +19,7 @@
  */
 package com.p6spy.engine.spy;
 
+import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.P6LogQuery;
 
 import java.sql.Connection;
@@ -91,12 +92,9 @@ public class P6SpyDriver implements Driver {
 
     P6LogQuery.debug("this is " + this + " and passthru is " + passThru);
 
+    final long start = System.nanoTime();
     Connection conn = passThru.connect(extractRealUrl(url), properties);
-
-    if (conn != null) {
-      conn = P6Core.wrapConnection(conn);
-    }
-    return conn;
+    return P6Core.wrapConnection(conn, ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start));
   }
 
   protected Driver findPassthru(String url) throws SQLException {

--- a/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
@@ -59,22 +59,30 @@ public class ConnectionWrapper extends AbstractWrapper implements Connection {
   private final JdbcEventListener eventListener;
   private final ConnectionInformation connectionInformation;
 
-  public static Connection wrap(Connection delegate, JdbcEventListener eventListener) {
+  public static Connection wrap(Connection delegate, JdbcEventListener eventListener, ConnectionInformation connectionInformation) {
     if (delegate == null) {
       return null;
     }
-    return new ConnectionWrapper(delegate, eventListener);
+    return new ConnectionWrapper(delegate, eventListener, connectionInformation);
   }
 
-  public ConnectionWrapper(Connection delegate, JdbcEventListener eventListener) {
+  private ConnectionWrapper(Connection delegate, JdbcEventListener eventListener, ConnectionInformation connectionInformation) {
     super(delegate);
     this.delegate = delegate;
     this.eventListener = eventListener;
-    connectionInformation = new ConnectionInformation();
+    this.connectionInformation = connectionInformation;
   }
 
   public JdbcEventListener getEventListener() {
     return eventListener;
+  }
+
+  public Connection getDelegate() {
+    return delegate;
+  }
+
+  public ConnectionInformation getConnectionInformation() {
+    return connectionInformation;
   }
 
   @Override

--- a/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
@@ -19,28 +19,29 @@
  */
 package com.p6spy.engine.common;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.p6spy.engine.test.AbstractTestConnection;
+import com.p6spy.engine.test.BaseTestCase;
+import com.p6spy.engine.test.TestConnection;
+import com.p6spy.engine.test.TestConnectionImpl;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
+
+import org.apache.commons.dbcp.DelegatingConnection;
+import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Wrapper;
 
-import com.p6spy.engine.test.AbstractTestConnection;
-import com.p6spy.engine.test.BaseTestCase;
-import com.p6spy.engine.test.TestConnection;
-import com.p6spy.engine.test.TestConnectionImpl;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
-import org.apache.commons.dbcp.DelegatingConnection;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
 
   @Test
   public void testCastableFromProxy() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
 
     // if the proxy implements the interface then true should be returned.
     assertTrue(proxy.isWrapperFor(Connection.class));
@@ -51,7 +52,7 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromUnderlying() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
 
     // if the underlying object extends the class (or matches the class) then true should be returned.
     assertTrue(proxy.isWrapperFor(TestConnectionImpl.class));
@@ -68,7 +69,7 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
     // is implemented here.
     DelegatingConnection underlying = new DelegatingConnection(con);
 
-    Connection proxy = ConnectionWrapper.wrap(underlying, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(underlying, noOpEventListener, ConnectionInformation.fromTestConnection(con));
 
     // TestConnection is an interface of the wrapped underlying object.
     assertTrue(proxy.isWrapperFor(TestConnection.class));

--- a/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
@@ -42,7 +42,7 @@ public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromProxy() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
 
     // if the proxy implements the interface then the proxy should be returned
     {
@@ -71,7 +71,7 @@ public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromUnderlying() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
 
     // if the underlying object extends the class (or matches the class) then the underlying object should be returned.
     {
@@ -96,7 +96,7 @@ public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
     // is implemented here.
     DelegatingConnection underlying = new DelegatingConnection(con);
 
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener);
+    Connection proxy = ConnectionWrapper.wrap(underlying, noOpEventListener, ConnectionInformation.fromTestConnection(underlying));
 
     // TestConnection is an interface of the actual connection but not of the proxy.  Unwrapping works
     // but a proxy is not returned

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -19,6 +19,7 @@
  */
 package com.p6spy.engine.event;
 
+import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
 import com.p6spy.engine.spy.P6Core;
 import com.p6spy.engine.test.TestJdbcEventListener;
@@ -38,7 +39,8 @@ public class EventListenerServiceLoaderTest {
 
   @Test
   public void testServiceLoader() throws Exception {
-    final Connection connection = P6Core.wrapConnection(mock(Connection.class));
+    final Connection connectionMock = mock(Connection.class);
+    final Connection connection = P6Core.wrapConnection(connectionMock, ConnectionInformation.fromTestConnection(connectionMock));
     assertTrue(connection instanceof ConnectionWrapper);
     ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
     final JdbcEventListener eventListener = connectionWrapper.getEventListener();

--- a/src/test/java/com/p6spy/engine/test/P6TestFramework.java
+++ b/src/test/java/com/p6spy/engine/test/P6TestFramework.java
@@ -26,6 +26,7 @@ import com.p6spy.engine.spy.P6SpyOptions;
 import com.p6spy.engine.spy.P6TestUtil;
 import com.p6spy.engine.spy.appender.P6TestLogger;
 import com.p6spy.engine.spy.option.SpyDotProperties;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import org.apache.log4j.Logger;
 import org.junit.After;
@@ -36,7 +37,6 @@ import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -59,7 +59,7 @@ public abstract class P6TestFramework extends BaseTestCase {
 
   protected final String db;
 
-  protected Connection connection = null;
+  protected ConnectionWrapper connection = null;
 
   public P6TestFramework(String db) throws SQLException, IOException {
     this.db = db;
@@ -108,12 +108,10 @@ public abstract class P6TestFramework extends BaseTestCase {
     if (log.isDebugEnabled()) {
       log.debug("FRAMEWORK USING DRIVER == " + driver.getClass().getName() + " FOR URL " + url);
     }
-    connection = DriverManager.getConnection(url, user, password);
+    connection = DriverManager.getConnection(url, user, password).unwrap(ConnectionWrapper.class);
 
     P6TestUtil.printAllDrivers();
     P6TestUtil.setupTestData(url, user, password);
-
-
   }
 
   @After

--- a/src/test/java/com/p6spy/engine/test/ResultSetInformationTest.java
+++ b/src/test/java/com/p6spy/engine/test/ResultSetInformationTest.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * P6Spy
+ * %%
+ * Copyright (C) 2002 - 2016 P6Spy
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.p6spy.engine.test;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.spy.P6SpyDriver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class ResultSetInformationTest extends P6TestFramework {
+
+  public ResultSetInformationTest(String db) throws SQLException, IOException {
+    super(db);
+  }
+
+  @Test
+  public void testResultSetInformation() throws Exception {
+    final ConnectionInformation connectionInformation = connection.getConnectionInformation();
+    assertSame(connection.getDelegate(), connectionInformation.getConnection());
+    assertNotNull(connectionInformation.getDriver());
+    assertNotEquals(P6SpyDriver.class, connectionInformation.getDriver().getClass());
+    assertTrue(connectionInformation.getTimeToGetConnectionNs() > 0);
+  }
+}


### PR DESCRIPTION
That way JdbcEventListeners have access for example to the MetaData of the Connection
to associate the execution with a Database URL. JdbcEventListeners can also reason about
how the connection was obtained (Driver/DataSource/PooledConnection) and how long
it took to get the connection. High connection times can for example indicate a exhausted
connection pool.