### PR TITLE
javadoc.io reference introduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ p6spy
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/p6spy/p6spy/badge.svg)](https://maven-badges.herokuapp.com/maven-central/p6spy/p6spy) 
 [![Bintray](https://api.bintray.com/packages/p6spy/maven/p6spy%3Ap6spy/images/download.svg) ](https://bintray.com/p6spy/maven/p6spy%3Ap6spy/_latestVersion) 
 [![Docs](http://readthedocs.org/projects/p6spy/badge/?version=latest)](http://p6spy.readthedocs.io/) 
+[![Javadoc](http://www.javadoc.io/badge/p6spy/p6spy.svg)](http://www.javadoc.io/doc/p6spy/p6spy) 
 [![Coverage Status](https://coveralls.io/repos/github/p6spy/p6spy/badge.svg?branch=master)](https://coveralls.io/github/p6spy/p6spy?branch=master)
 
 P6Spy is a framework that enables database data to be seamlessly intercepted and logged with no code changes to existing application. The P6Spy distribution includes P6Log, an application which logs all JDBC transactions for any Java application.
 
 **Documentation:**    
 [Installation](http://p6spy.readthedocs.io/en/latest/install.html)    
-[Configuration](http://p6spy.readthedocs.io/en/latest/configandusage.html)
+[Configuration](http://p6spy.readthedocs.io/en/latest/configandusage.html)    
+[Javadoc](http://www.javadoc.io/doc/p6spy/p6spy)
 
 For full documentation refer to format of your choice: [html](http://p6spy.readthedocs.io/), [pdf] (https://media.readthedocs.org/pdf/p6spy/latest/p6spy.pdf) or [epub] (https://media.readthedocs.org/epub/p6spy/latest/p6spy.epub).
 


### PR DESCRIPTION
there is hosting for javadoc available (javadoc.io) taking the fresh stuff from the maven central repo.
feel free to merge if you find it useful