### PR TITLE
StatementInformation.getSqlWithValues() returns getSql() rather than "" (fixes #361)

### DIFF
--- a/src/main/java/com/p6spy/engine/common/StatementInformation.java
+++ b/src/main/java/com/p6spy/engine/common/StatementInformation.java
@@ -53,7 +53,7 @@ public class StatementInformation implements Loggable {
 
   @Override
   public String getSqlWithValues() {
-    return "";
+    return getSql();
   }
 
   @Override


### PR DESCRIPTION
well it can be considered a breaking change, but sounds like it would make sense