### PR TITLE
depending on travis CI deprecated environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+# for now we depend upon deprecated CI infrastructure (to keep builds green): https://blog.travis-ci.com/2017-05-04-precise-image-updates
+group: deprecated-2017Q1
+
 jdk:
   - oraclejdk7
   - openjdk7


### PR DESCRIPTION
as reported officially: https://blog.travis-ci.com/2017-05-04-precise-image-updates we need deprecated infrastructure from now on (until we'll find a better way for environment provisioning)