### PR TITLE
feat: introduced event onAfterConnectionGet (fixes #381)

### DIFF
--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -62,6 +62,7 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
   }
 
   @Override
+  @Deprecated
   public void onConnectionWrapped(ConnectionInformation connectionInformation) {
     for (JdbcEventListener eventListener : eventListeners) {
       eventListener.onConnectionWrapped(connectionInformation);

--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -55,6 +55,13 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
   }
 
   @Override
+  public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+    for (JdbcEventListener eventListener : eventListeners) {
+      eventListener.onAfterGetConnection(connectionInformation, e);
+    }
+  }
+
+  @Override
   public void onConnectionWrapped(ConnectionInformation connectionInformation) {
     for (JdbcEventListener eventListener : eventListeners) {
       eventListener.onConnectionWrapped(connectionInformation);

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -25,8 +25,11 @@ import com.p6spy.engine.common.PreparedStatementInformation;
 import com.p6spy.engine.common.ResultSetInformation;
 import com.p6spy.engine.common.StatementInformation;
 
+import javax.sql.DataSource;
+
 import java.sql.CallableStatement;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -51,6 +54,21 @@ import java.sql.Statement;
 public abstract class JdbcEventListener {
 
   /**
+   * This callback method is executed after a {@link Connection} obtained from a {@link DataSource} or a {@link Driver}.
+   * <p/>
+   * The {@link ConnectionInformation} holds information about the creator of the connection which is either
+   * {@link ConnectionInformation#dataSource}, {@link ConnectionInformation#driver} or
+   * {@link ConnectionInformation#pooledConnection}, though {@link ConnectionInformation#connection} itself is <code>null</code>
+   * when {@link SQLException} is not <code>null</code> and vise versa.
+   *
+   * @param connectionInformation The meta information about the wrapped {@link Connection}
+   * @param e                     The {@link SQLException} which may be triggered by the call (<code>null</code> if
+   *                              there was no exception).
+   */
+  public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+  }
+
+  /**
    * This callback method is executed after a wrapped {@link Connection} has been created.
    * <p/>
    * The {@link ConnectionInformation} holds information about the creator of the connection which is either
@@ -58,6 +76,8 @@ public abstract class JdbcEventListener {
    * {@link ConnectionInformation#pooledConnection}.
    *
    * @param connectionInformation The meta information about the wrapped {@link Connection}
+   *
+   * @deprecated Use {@link #onAfterGetConnection(ConnectionInformation, SQLException)}
    */
   public void onConnectionWrapped(ConnectionInformation connectionInformation) {
   }

--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -39,15 +39,20 @@ public class P6Core {
 
   private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = ServiceLoader.load(JdbcEventListener.class, P6Core.class.getClassLoader());
 
+  @Deprecated
   public static Connection wrapConnection(Connection realConnection, ConnectionInformation connectionInformation) {
     if (realConnection == null) {
       return null;
     }
-    final CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
+    return ConnectionWrapper.wrap(realConnection, getJdbcEventListener(), connectionInformation);
+  }
+
+  public static JdbcEventListener getJdbcEventListener() {
+    CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
     compoundEventListener.addListender(DefaultEventListener.INSTANCE);
     registerEventListenersFromFactories(compoundEventListener);
     registerEventListenersFromServiceLoader(compoundEventListener);
-    return ConnectionWrapper.wrap(realConnection, compoundEventListener, connectionInformation);
+    return compoundEventListener;
   }
 
   private static void registerEventListenersFromFactories(CompoundJdbcEventListener compoundEventListener) {

--- a/src/main/java/com/p6spy/engine/spy/P6DataSource.java
+++ b/src/main/java/com/p6spy/engine/spy/P6DataSource.java
@@ -21,6 +21,8 @@ package com.p6spy.engine.spy;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -284,9 +286,17 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     if (realDataSource == null) {
       bindDataSource();
     }
+    JdbcEventListener jdbcEventListener = P6Core.getJdbcEventListener();
     final long start = System.nanoTime();
-    final Connection connection = ((DataSource) realDataSource).getConnection();
-    return P6Core.wrapConnection(connection, ConnectionInformation.fromDataSource(realDataSource, connection, System.nanoTime() - start));
+    try {
+      final Connection conn = ((DataSource) realDataSource).getConnection();
+      ConnectionInformation connectionInformation = ConnectionInformation.fromDataSource(realDataSource, conn, System.nanoTime() - start);
+      jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+      return ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    } catch (SQLException e) {
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
+      throw e;
+    }
   }
 
   @Override
@@ -294,9 +304,17 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     if (realDataSource == null) {
       bindDataSource();
     }
+    JdbcEventListener jdbcEventListener = P6Core.getJdbcEventListener();
     final long start = System.nanoTime();
-    final Connection connection = ((DataSource) realDataSource).getConnection(username, password);
-    return P6Core.wrapConnection(connection, ConnectionInformation.fromDataSource(realDataSource, connection, System.nanoTime() - start));
+    try {
+      final Connection conn = ((DataSource) realDataSource).getConnection(username, password);
+      ConnectionInformation connectionInformation = ConnectionInformation.fromDataSource(realDataSource, conn, System.nanoTime() - start);
+      jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+      return ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    } catch (SQLException e) {
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
+      throw e;
+    }
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
+++ b/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
@@ -20,6 +20,8 @@
 package com.p6spy.engine.spy;
 
 import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -38,9 +40,17 @@ public class P6PooledConnection implements PooledConnection {
 
   @Override
   public Connection getConnection() throws SQLException {
-    long start = System.nanoTime();
-    final Connection connection = passthru.getConnection();
-    return P6Core.wrapConnection(connection, ConnectionInformation.fromPooledConnection(passthru, connection, System.nanoTime() - start));
+    JdbcEventListener jdbcEventListener = P6Core.getJdbcEventListener();
+    final long start = System.nanoTime();
+    try {
+      final Connection conn = passthru.getConnection();
+      ConnectionInformation connectionInformation = ConnectionInformation.fromPooledConnection(passthru, conn, System.nanoTime() - start);
+      jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+      return ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    } catch (SQLException e) {
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromPooledConnection(passthru, null, System.nanoTime() - start), e);
+      throw e;
+    }
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -21,6 +21,8 @@ package com.p6spy.engine.spy;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import java.sql.Connection;
 import java.sql.Driver;
@@ -92,9 +94,17 @@ public class P6SpyDriver implements Driver {
 
     P6LogQuery.debug("this is " + this + " and passthru is " + passThru);
 
+    JdbcEventListener jdbcEventListener = P6Core.getJdbcEventListener();
     final long start = System.nanoTime();
-    Connection conn = passThru.connect(extractRealUrl(url), properties);
-    return P6Core.wrapConnection(conn, ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start));
+    try {
+      final Connection conn =  passThru.connect(extractRealUrl(url), properties);
+      ConnectionInformation connectionInformation = ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start);
+      jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+      return ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    } catch (SQLException e) {
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDriver(passThru, null, System.nanoTime() - start), e);
+      throw e;
+    }
   }
 
   protected Driver findPassthru(String url) throws SQLException {

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -22,10 +22,15 @@ package com.p6spy.engine.event;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -37,6 +42,7 @@ import java.sql.CallableStatement;
 import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.Date;
+import java.sql.DriverManager;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.Ref;
@@ -48,9 +54,15 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 
+import com.p6spy.engine.spy.P6DataSource;
+import com.p6spy.engine.spy.P6PooledConnection;
+import com.p6spy.engine.test.P6TestFactory;
+import com.p6spy.engine.test.P6TestFramework;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -64,11 +76,21 @@ import com.p6spy.engine.wrapper.ConnectionWrapper;
 import com.p6spy.engine.wrapper.PreparedStatementWrapper;
 import com.p6spy.engine.wrapper.StatementWrapper;
 
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+
 @RunWith(MockitoJUnitRunner.class)
 public class CompoundJdbcEventListenerTest {
 
   @Mock
+  private DataSource mockedDataSource;
+  @Mock
+  private PooledConnection mockedPooledConnection;
+  @Mock
   private JdbcEventListener mockedJdbcListener;
+
+  private DataSource wrappedDataSource;
+  private PooledConnection wrappedPooledConnection;
 
   private Connection wrappedConnection;
   private Statement wrappedStatement;
@@ -83,11 +105,21 @@ public class CompoundJdbcEventListenerTest {
   private static final String SQL = "SELECT * FROM DUAL";
 
   @Before
-  public void before() {
+  public void before() throws SQLException, IOException {
+    P6TestFactory.setJdbcEventListener(mockedJdbcListener);
+    new P6TestFramework("H2") {
+    };
+
     final Connection mockedConnection = mock(Connection.class);
     final Statement mockedStatement = mock(Statement.class);
     final PreparedStatement mockedPreparedStatement = mock(PreparedStatement.class);
     final CallableStatement mockedCallableStatement = mock(CallableStatement.class);
+
+    wrappedDataSource = new P6DataSource(mockedDataSource);
+    wrappedPooledConnection = new P6PooledConnection(mockedPooledConnection);
+    when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
+    when(mockedDataSource.getConnection(anyString(), anyString())).thenReturn(mockedConnection);
+    when(mockedPooledConnection.getConnection()).thenReturn(mockedConnection);
 
     connectionInformation = ConnectionInformation.fromTestConnection(mockedConnection);
     statementInformation = new StatementInformation(connectionInformation);
@@ -101,6 +133,68 @@ public class CompoundJdbcEventListenerTest {
         mockedJdbcListener);
     wrappedCallableStatement = CallableStatementWrapper.wrap(mockedCallableStatement, callableStatementInformation,
         mockedJdbcListener);
+  }
+
+  @After
+  public void after() throws Exception {
+    P6TestFactory.setJdbcEventListener(null);
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromDataSource() throws SQLException {
+    wrappedDataSource.getConnection();
+    wrappedDataSource.getConnection("test", "test");
+    verify(mockedJdbcListener, times(2)).onAfterGetConnection(connectionInformationWithConnection(), ArgumentMatchers.<SQLException>isNull());
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromDataSourceWithThrowingSQLException() throws SQLException {
+    SQLException sqle = new SQLException();
+    when(mockedDataSource.getConnection()).thenThrow(sqle);
+    when(mockedDataSource.getConnection(anyString(), anyString())).thenThrow(sqle);
+
+    try {
+      wrappedDataSource.getConnection();
+    } catch (SQLException expected) {
+    }
+    try {
+      wrappedDataSource.getConnection("test", "test");
+    } catch (SQLException expected) {
+    }
+    verify(mockedJdbcListener, times(2)).onAfterGetConnection(connectionInformationWithoutConnection(), eq(sqle));
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromDriver() throws SQLException {
+    DriverManager.getConnection("jdbc:p6spy:h2:mem:p6spy", "sa", null);
+    verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithConnection(), ArgumentMatchers.<SQLException>isNull());
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromDriverWithThrowingSQLException() throws SQLException {
+    try {
+      DriverManager.getConnection("jdbc:p6spy:h2:tcp://dev/null/", "sa", null);
+    } catch (SQLException expected) {
+    }
+    verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithoutConnection(), any(SQLException.class));
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromPooledConnection() throws SQLException {
+    wrappedPooledConnection.getConnection();
+    verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithConnection(), ArgumentMatchers.<SQLException>isNull());
+  }
+
+  @Test
+  public void testConnectionOnAfterGetConnectionAfterGettingFromPooledConnectionWithThrowingSQLException() throws SQLException {
+    SQLException sqle = new SQLException();
+    when(mockedPooledConnection.getConnection()).thenThrow(sqle);
+
+    try {
+      wrappedPooledConnection.getConnection();
+    } catch (SQLException expected) {
+    }
+    verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithoutConnection(), eq(sqle));
   }
 
   @Test
@@ -944,6 +1038,24 @@ public class CompoundJdbcEventListenerTest {
   public void testStatementOnAfterStatementClose() throws SQLException {
     wrappedStatement.close();
     verify(mockedJdbcListener).onAfterStatementClose(eq(statementInformation), ArgumentMatchers.<SQLException>isNull());
+  }
+
+  private ConnectionInformation connectionInformationWithConnection() {
+    return argThat(new ArgumentMatcher<ConnectionInformation>() {
+      @Override
+      public boolean matches(ConnectionInformation connectionInformation) {
+        return connectionInformation.getConnection() != null;
+      }
+    });
+  }
+
+  private ConnectionInformation connectionInformationWithoutConnection() {
+    return argThat(new ArgumentMatcher<ConnectionInformation>() {
+      @Override
+      public boolean matches(ConnectionInformation connectionInformation) {
+        return connectionInformation.getConnection() == null;
+      }
+    });
   }
 
 }

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -59,6 +59,7 @@ import com.p6spy.engine.spy.P6PooledConnection;
 import com.p6spy.engine.test.P6TestFactory;
 import com.p6spy.engine.test.P6TestFramework;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,10 +156,12 @@ public class CompoundJdbcEventListenerTest {
 
     try {
       wrappedDataSource.getConnection();
+      Assert.fail("exception should be thrown");
     } catch (SQLException expected) {
     }
     try {
       wrappedDataSource.getConnection("test", "test");
+      Assert.fail("exception should be thrown");
     } catch (SQLException expected) {
     }
     verify(mockedJdbcListener, times(2)).onAfterGetConnection(connectionInformationWithoutConnection(), eq(sqle));
@@ -174,6 +177,7 @@ public class CompoundJdbcEventListenerTest {
   public void testConnectionOnAfterGetConnectionAfterGettingFromDriverWithThrowingSQLException() throws SQLException {
     try {
       DriverManager.getConnection("jdbc:p6spy:h2:tcp://dev/null/", "sa", null);
+      Assert.fail("exception should be thrown");
     } catch (SQLException expected) {
     }
     verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithoutConnection(), any(SQLException.class));
@@ -192,6 +196,7 @@ public class CompoundJdbcEventListenerTest {
 
     try {
       wrappedPooledConnection.getConnection();
+      Assert.fail("exception should be thrown");
     } catch (SQLException expected) {
     }
     verify(mockedJdbcListener).onAfterGetConnection(connectionInformationWithoutConnection(), eq(sqle));

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -19,23 +19,47 @@
  */
 package com.p6spy.engine.event;
 
+import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
 import com.p6spy.engine.spy.P6Core;
 import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
 
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.junit.Test;
 
+import java.sql.Connection;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class EventListenerServiceLoaderTest {
 
   @Test
   public void testServiceLoader() throws Exception {
-    CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) P6Core.getJdbcEventListener();
+    JdbcEventListener eventListener = P6Core.getJdbcEventListener();
+    assertTrue(eventListener instanceof CompoundJdbcEventListener);
+
+    CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) eventListener;
+
+    final List<JdbcEventListener> eventListeners = compoundJdbcEventListener.getEventListeners();
+    assertTrue(containsClass(TestJdbcEventListener.class, eventListeners));
+    assertFalse(containsClass(JdbcEventListener.class, eventListeners));
+    assertTrue(containsClass(TestLoggingEventListener.class, eventListeners));
+    assertFalse(containsClass(LoggingEventListener.class, eventListeners));
+  }
+
+  @Test
+  public void testServiceLoaderFromWrapConnection() throws Exception {
+    final Connection connectionMock = mock(Connection.class);
+    final Connection connection = P6Core.wrapConnection(connectionMock, ConnectionInformation.fromTestConnection(connectionMock));
+    assertTrue(connection instanceof ConnectionWrapper);
+    ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
+    final JdbcEventListener eventListener = connectionWrapper.getEventListener();
+    assertTrue(eventListener instanceof CompoundJdbcEventListener);
+    CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) eventListener;
 
     final List<JdbcEventListener> eventListeners = compoundJdbcEventListener.getEventListeners();
     assertTrue(containsClass(TestJdbcEventListener.class, eventListeners));

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -19,33 +19,23 @@
  */
 package com.p6spy.engine.event;
 
-import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
 import com.p6spy.engine.spy.P6Core;
 import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import org.junit.Test;
 
-import java.sql.Connection;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class EventListenerServiceLoaderTest {
 
   @Test
   public void testServiceLoader() throws Exception {
-    final Connection connectionMock = mock(Connection.class);
-    final Connection connection = P6Core.wrapConnection(connectionMock, ConnectionInformation.fromTestConnection(connectionMock));
-    assertTrue(connection instanceof ConnectionWrapper);
-    ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
-    final JdbcEventListener eventListener = connectionWrapper.getEventListener();
-    assertTrue(eventListener instanceof CompoundJdbcEventListener);
-    CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) eventListener;
+    CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) P6Core.getJdbcEventListener();
 
     final List<JdbcEventListener> eventListeners = compoundJdbcEventListener.getEventListeners();
     assertTrue(containsClass(TestJdbcEventListener.class, eventListeners));

--- a/src/test/java/com/p6spy/engine/test/P6TestFactory.java
+++ b/src/test/java/com/p6spy/engine/test/P6TestFactory.java
@@ -26,6 +26,8 @@ import com.p6spy.engine.spy.option.P6OptionsRepository;
 
 public class P6TestFactory implements P6Factory {
 
+  private static JdbcEventListener jdbcEventListener;
+
   @Override
   public P6LoadableOptions getOptions(P6OptionsRepository optionsRepository) {
     return new P6TestOptions(optionsRepository);
@@ -33,7 +35,10 @@ public class P6TestFactory implements P6Factory {
 
   @Override
   public JdbcEventListener getJdbcEventListener() {
-    return null;
+    return jdbcEventListener;
   }
 
+  public static void setJdbcEventListener(JdbcEventListener jdbcEventListener) {
+    P6TestFactory.jdbcEventListener = jdbcEventListener;
+  }
 }


### PR DESCRIPTION
fixes #381 

I have done everything as @felixbarny suggested, only one difference that call `onAfterConnectionGet` is cleaner to do not in `finally` but after getting a connection and in `catch` itself. Otherwise as `ConnectionInformation` must be created only once i should do the following:
```
    ConnectionInformation connectionInformation = null;
    SQLException e = null;
    final long start = System.nanoTime();
    try {
      final Connection conn = ((DataSource) realDataSource).getConnection();
      connectionInformation = ConnectionInformation.fromDataSource(realDataSource, conn, System.nanoTime() - start);
      return ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
    } catch (SQLException sqle) {
      connectionInformation = ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start);
      e = sqle;
      throw e;
    } finally {
        jdbcEventListener.onAfterGetConnection(connectionInformation, e);
    }
```
So that in case of `RuntimeException` it calls `onAfterGetConnection(null, null)`, although creating `ConnectionInformation` in `catch(RuntimeException)` is also an option.