### PR TITLE
[Inquiry] `StatementInformation.getSql()` null for connection-pool validation queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,12 @@
       <version>1.4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-jdbc</artifactId>
+      <version>8.5.6</version>
+      <scope>test</scope>
+    </dependency>
     <!-- xa datasource testing  -->
     <dependency>
       <groupId>org.codehaus.btm</groupId>

--- a/src/test/java/com/p6spy/engine/spy/P6TestPool.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestPool.java
@@ -1,0 +1,53 @@
+package com.p6spy.engine.spy;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.StatementInformation;
+import com.p6spy.engine.event.SimpleJdbcEventListener;
+import com.p6spy.engine.test.P6TestFramework;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class P6TestPool extends P6TestFramework {
+
+  public P6TestPool(String db) throws SQLException, IOException {
+    super(db);
+
+
+    org.apache.tomcat.jdbc.pool.DataSource ds = new org.apache.tomcat.jdbc.pool.DataSource();
+    ds.setDriverClassName("com.p6spy.engine.spy.P6SpyDriver");
+    ds.setUsername("sa");
+    ds.setPassword("");
+    ds.setUrl("jdbc:p6spy:h2:mem:p6spy");
+    ds.setTestOnBorrow(true);
+    ds.setTestOnConnect(true);
+    ds.setValidationQuery("SELECT 1");
+
+    connection = ds.getConnection().unwrap(ConnectionWrapper.class);
+  }
+
+
+  @Test
+  public void testExecute() throws SQLException {
+    String query = "select 2";
+
+    final Connection connectionWrapper = ConnectionWrapper.wrap(this.connection, new SimpleJdbcEventListener() {
+      @Override
+      public void onBeforeAnyExecute(StatementInformation statementInformation) {
+        assertThat("sql of statementInformation", statementInformation.getSql(), is(notNullValue()));
+      }
+    }, ConnectionInformation.fromTestConnection(this.connection));
+
+    P6TestUtil.execute(connectionWrapper, query);
+  }
+}


### PR DESCRIPTION
Hi there!

I stumbled into a rabbit-hole when trying to use https://github.com/openzipkin/brave that eventually led me to this failing test-case PR.

So, what's the story?

`brave` has a `p6spy` integration that captures SQL queries inside a trace context. For this, it is implementing a module (`brave.p6spy.TracingP6Factory`) and caputing events using a subclass from `SimpleJdbcEventListener` (see
https://github.com/openzipkin/brave/blob/master/instrumentation/p6spy/src/main/java/brave/p6spy/TracingJdbcEventListener.java#L23-L38).

This all worked brilliantly at first but then started  throwing NPEs all of the sudden. In `P6TestPool.java` I was able to reproduce this issue:

When using a pooled-connection (tomcat-jdbc in my case) `p6spy` is providing `null` values in the `onBeforeAnyExecute` callback.

```
java.lang.AssertionError: sql of statementInformation
Expected: is not null
     but: was null
```

I am not sure if this is a design choice or something is actually wrong here.

Any feedback is very much appreciated!

cc @adriancole (`brave` maintainer)