### PR TITLE
Added support for specifying log message format from configuration file

### DIFF
--- a/docs/configandusage.md
+++ b/docs/configandusage.md
@@ -135,6 +135,19 @@ in section: [Configuration and Usage](#configuration-and-usage)):
 
     # class to use for formatting log messages (default is: com.p6spy.engine.spy.appender.SingleLineFormat)
     #logMessageFormat=com.p6spy.engine.spy.appender.SingleLineFormat
+    
+    # Custom log message format used ONLY IF logMessageFormat is set to com.p6spy.engine.spy.appender.CustomLineFormat
+    # default is %(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sqlSingleLine)
+    # Available placeholders are:
+    #   %(connectionId)           the id of the connection
+    #   %(currentTime)                    the current time expressing in milliseconds
+    #   %(executionTime)          the time in milliseconds that the operation took to complete
+    #   %(category)               the category of the operation
+    #   %(effectiveSql)           the SQL statement as submitted to the driver
+    #   %(effectiveSqlSingleLine) the SQL statement as submitted to the driver, with all new lines removed
+    #   %(sql)                    the SQL statement with all bind variables replaced with actual values
+    #   %(sqlSingleLine)          the SQL statement with all bind variables replaced with actual values, with all new lines removed
+    #customLogMessageFormat=%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sqlSingleLine)
 
     # format that is used for logging of the date/time/... (has to be compatible with java.text.SimpleDateFormat)
     # (default is dd-MMM-yy)
@@ -414,6 +427,9 @@ classes are available with P6Spy.
 
 		current time|execution time|category|connection id|statement SQL String|effective SQL string
 		
+* `com.p6spy.engine.spy.appender.CustomLineFormat`, which allows log messages to be full customized, in a separate
+    property called `customLogMessageFormat`. See below for details.
+		
 * `com.p6spy.engine.spy.appender.MultiLineFormat`, which results in log messages in format: 
 		
 		current time|execution time|category|connection id|statement SQL String
@@ -451,6 +467,22 @@ The default is `com.p6spy.engine.spy.appender.SingleLineFormat` for backward com
 
 You can also supply your own log message formatter to customize the format.  Simply create a class which implements
 the `com.p6spy.engine.spy.appender.MessageFormattingStrategy` interface and place it on the classpath.
+
+### customLogMessageFormat
+
+The custom log message format to use when 'logMessageFormat' is set to `com.p6spy.engine.spy.appender.CustomLineFormat`
+
+The message is build out of the format string, with the all the Java special characters supported (`\n`, `\t` etc) 
+and the following placeholders being resolved to the appropriate values:
+
+* `%(connectionId)`           the id of the connection
+* `%(currentTime)`                    the current time expressing in milliseconds
+* `%(executionTime)`          the time in milliseconds that the operation took to complete
+* `%(category)`               the category of the operation
+* `%(effectiveSql)`           the SQL statement as submitted to the driver
+* `%(effectiveSqlSingleLine)` the SQL statement as submitted to the driver, with all new lines removed
+* `%(sql)`                    the SQL statement with all bind variables replaced with actual values
+* `%(sqlSingleLine)`          the SQL statement with all bind variables replaced with actual values, with all new lines removed
 
 ### filter, include, exclude
 

--- a/src/main/assembly/individualFiles/spy.properties
+++ b/src/main/assembly/individualFiles/spy.properties
@@ -98,6 +98,19 @@
 # class to use for formatting log messages (default is: com.p6spy.engine.spy.appender.SingleLineFormat)
 #logMessageFormat=com.p6spy.engine.spy.appender.SingleLineFormat
 
+# Custom log message format used ONLY IF logMessageFormat is set to com.p6spy.engine.spy.appender.CustomLineFormat
+# default is %(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sqlSingleLine)
+# Available placeholders are:
+#   %(connectionId)            the id of the connection
+#   %(currentTime)                     the current time expressing in milliseconds
+#   %(executionTime)           the time in milliseconds that the operation took to complete
+#   %(category)                the category of the operation
+#   %(effectiveSql)            the SQL statement as submitted to the driver
+#   %(effectiveSqlSingleLine)  the SQL statement as submitted to the driver, with all new lines removed
+#   %(sql)                     the SQL statement with all bind variables replaced with actual values
+#   %(sqlSingleLine)           the SQL statement with all bind variables replaced with actual values, with all new lines removed
+#customLogMessageFormat=%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sqlSingleLine)
+
 # format that is used for logging of the date/time/... (has to be compatible with java.text.SimpleDateFormat)
 # (default is dd-MMM-yy)
 #databaseDialectDateFormat=dd-MMM-yy

--- a/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
@@ -26,10 +26,7 @@ import javax.management.StandardMBean;
 
 import com.p6spy.engine.common.P6Util;
 import com.p6spy.engine.logging.P6LogFactory;
-import com.p6spy.engine.spy.appender.FileLogger;
-import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
-import com.p6spy.engine.spy.appender.P6Logger;
-import com.p6spy.engine.spy.appender.SingleLineFormat;
+import com.p6spy.engine.spy.appender.*;
 import com.p6spy.engine.spy.option.P6OptionsRepository;
 
 public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions {
@@ -52,6 +49,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
     public static final String REALDATASOURCE = "realdatasource";
     public static final String REALDATASOURCECLASS = "realdatasourceclass";
     public static final String REALDATASOURCEPROPERTIES = "realdatasourceproperties";
+    public static final String CUSTOM_LOG_MESSAGE_FORMAT = "customLogMessageFormat";
     public static final String DATABASE_DIALECT_DATE_FORMAT = "databaseDialectDateFormat";
     public static final String JMX = "jmx";
     public static final String JMX_PREFIX = "jmxPrefix";
@@ -77,6 +75,9 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       defaults.put(RELOADPROPERTIES, Boolean.FALSE.toString());
       defaults.put(RELOADPROPERTIESINTERVAL, Long.toString(60));
       defaults.put(DATABASE_DIALECT_DATE_FORMAT, "dd-MMM-yy");
+      defaults.put(CUSTOM_LOG_MESSAGE_FORMAT, String.format("%s|%s|%s|connection%s|%s",
+        CustomLineFormat.CURRENT_TIME, CustomLineFormat.EXECUTION_TIME, CustomLineFormat.CATEGORY,
+        CustomLineFormat.CONNECTION_ID, CustomLineFormat.SQL_SINGLE_LINE));
       defaults.put(JMX, Boolean.TRUE.toString());
     }
 
@@ -108,6 +109,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       setRealDataSourceClass(options.get(REALDATASOURCECLASS));
       setRealDataSourceProperties(options.get(REALDATASOURCEPROPERTIES));
       setDatabaseDialectDateFormat(options.get(DATABASE_DIALECT_DATE_FORMAT));
+      setCustomLogMessageFormat(options.get(CUSTOM_LOG_MESSAGE_FORMAT));
       setJmx(options.get(JMX));
       setJmxPrefix(options.get(JMX_PREFIX));
     }
@@ -301,6 +303,27 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
     @Override
     public void setDatabaseDialectDateFormat(String databaseDialectDateFormat) {
       optionsRepository.set(String.class, DATABASE_DIALECT_DATE_FORMAT, databaseDialectDateFormat);
+    }
+
+    /**
+     * Returns the customLogMessageFormat.
+     *
+     * @return String
+     */
+    @Override
+    public String getCustomLogMessageFormat() {
+      return optionsRepository.get(String.class, CUSTOM_LOG_MESSAGE_FORMAT);
+    }
+
+
+    /**
+     * Sets the customLogMessageFormat.
+     *
+     * @param customLogMessageFormat The CustomLogMessageFormat to set
+     */
+    @Override
+    public void setCustomLogMessageFormat(String customLogMessageFormat) {
+      optionsRepository.set(String.class, CUSTOM_LOG_MESSAGE_FORMAT, customLogMessageFormat);
     }
 
 

--- a/src/main/java/com/p6spy/engine/spy/P6SpyOptionsMBean.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyOptionsMBean.java
@@ -91,6 +91,10 @@ public interface P6SpyOptionsMBean {
 
   void setDatabaseDialectDateFormat(String databaseDialectDateFormat);
 
+  String getCustomLogMessageFormat();
+
+  void setCustomLogMessageFormat(String customLogMessageFormat);
+
   void setAppend(boolean append);
 
   boolean getAppend();

--- a/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
@@ -1,0 +1,74 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2017 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.p6spy.engine.spy.appender;
+
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.spy.P6SpyOptions;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Peter G. Horvath
+ * @since 08/2017
+ */
+public class CustomLineFormat implements MessageFormattingStrategy {
+
+  private static final MessageFormattingStrategy FALLBACK_FORMATTING_STRATEGY = new SingleLineFormat();
+
+  public static final String CONNECTION_ID = "%(connectionId)";
+  public static final String CURRENT_TIME = "%(currentTime)";
+  public static final String EXECUTION_TIME = "%(executionTime)";
+  public static final String CATEGORY = "%(category)";
+  public static final String EFFECTIVE_SQL = "%(effectiveSql)";
+  public static final String EFFECTIVE_SQL_SINGLELINE = "%(effectiveSqlSingleLine)";
+  public static final String SQL = "%(sql)";
+  public static final String SQL_SINGLE_LINE = "%(sqlSingleLine)";
+
+  /**
+   * Formats a log message for the logging module
+   *
+   * @param connectionId the id of the connection
+   * @param now          the current ime expressing in milliseconds
+   * @param elapsed      the time in milliseconds that the operation took to complete
+   * @param category     the category of the operation
+   * @param prepared     the SQL statement with all bind variables replaced with actual values
+   * @param sql          the sql statement executed
+   * @return the formatted log message
+   */
+  @Override
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql) {
+
+    String customLogMessageFormat = P6SpyOptions.getActiveInstance().getCustomLogMessageFormat();
+
+    if (customLogMessageFormat == null) {
+      // Someone forgot to configure customLogMessageFormat: fall back to built-in
+      return FALLBACK_FORMATTING_STRATEGY.formatMessage(connectionId, now, elapsed, category, prepared, sql);
+    }
+
+    return customLogMessageFormat
+      .replace(Pattern.quote(CONNECTION_ID), Integer.toString(connectionId))
+      .replaceAll(Pattern.quote(CURRENT_TIME), now)
+      .replaceAll(Pattern.quote(EXECUTION_TIME), Long.toString(elapsed))
+      .replaceAll(Pattern.quote(CATEGORY), category)
+      .replaceAll(Pattern.quote(EFFECTIVE_SQL), prepared)
+      .replaceAll(Pattern.quote(EFFECTIVE_SQL_SINGLELINE), P6Util.singleLine(prepared))
+      .replaceAll(Pattern.quote(SQL), sql)
+      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), P6Util.singleLine(sql));
+  }
+}

--- a/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
@@ -31,6 +31,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.spy.appender.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,10 +39,6 @@ import org.junit.runners.Parameterized;
 
 import com.p6spy.engine.logging.Category;
 import com.p6spy.engine.logging.P6LogOptions;
-import com.p6spy.engine.spy.appender.MultiLineFormat;
-import com.p6spy.engine.spy.appender.P6TestLogger;
-import com.p6spy.engine.spy.appender.SingleLineFormat;
-import com.p6spy.engine.spy.appender.StdoutLogger;
 import com.p6spy.engine.spy.option.SystemProperties;
 import com.p6spy.engine.test.P6TestFramework;
 
@@ -463,6 +460,48 @@ public class P6TestCommon extends P6TestFramework {
       String query = "select count(*) from customers";
       statement.executeQuery(query);
       assertTrue(super.getLastLogEntry().contains("\n"));
+    }
+
+    // CustomLineFormat cases
+    {
+      // misconfiguration of CustomLineFormat cause it fall back to SingleLineFormat
+      P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomLineFormat.class.getName());
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+
+
+      String query = "select count(*) from customers";
+      statement.executeQuery(query);
+      assertFalse(super.getLastLogEntry().contains("\n"));
+      assertTrue(super.getLastLogEntry().contains("select count(*) from customers"));
+
+      // reset formatting setting
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+    }
+    {
+      P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomLineFormat.class.getName());
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat("SQL in custom format: #"+
+        CustomLineFormat.SQL+"#");
+
+
+      String query = "select count(*) from customers";
+      statement.executeQuery(query);
+      assertEquals("SQL in custom format: #select count(*) from customers#", super.getLastLogEntry());
+
+      // reset formatting setting
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+    }
+    {
+      P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomLineFormat.class.getName());
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat("SQL in custom format: #"+
+        CustomLineFormat.SQL +"#\n");
+
+
+      String query = "select count(*) from customers";
+      statement.executeQuery(query);
+      assertEquals("SQL in custom format: #select count(*) from customers#\n", super.getLastLogEntry());
+
+      // reset formatting setting
+      P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
     }
 
     // reset to default line format strategy

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
@@ -40,6 +40,7 @@ import com.p6spy.engine.spy.P6ModuleManager;
 import com.p6spy.engine.spy.P6SpyFactory;
 import com.p6spy.engine.spy.P6SpyLoadableOptions;
 import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.CustomLineFormat;
 import com.p6spy.engine.spy.appender.FileLogger;
 import com.p6spy.engine.spy.appender.SingleLineFormat;
 import com.p6spy.engine.test.BaseTestCase;
@@ -142,6 +143,10 @@ public class P6TestOptionDefaults extends BaseTestCase {
     Assert.assertNull(opts.getRealDataSource());
     Assert.assertNull(opts.getRealDataSourceClass());
     Assert.assertEquals("dd-MMM-yy", opts.getDatabaseDialectDateFormat());
+    Assert.assertEquals(String.format("%s|%s|%s|connection%s|%s",
+      CustomLineFormat.CURRENT_TIME, CustomLineFormat.EXECUTION_TIME, CustomLineFormat.CATEGORY,
+      CustomLineFormat.CONNECTION_ID, CustomLineFormat.SQL_SINGLE_LINE),
+      opts.getCustomLogMessageFormat());
     Assert.assertTrue(opts.getJmx());
     Assert.assertNull(opts.getJmxPrefix());
   }

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsRepository.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsRepository.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.p6spy.engine.spy.appender.CustomLineFormat;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,8 @@ public class P6TestOptionsRepository extends BaseTestCase {
         SingleLineFormat.class.getName()) instanceof MessageFormattingStrategy);
     Assert.assertTrue(optRepo.parse(MessageFormattingStrategy.class,
         MultiLineFormat.class.getName()) instanceof MessageFormattingStrategy);
+    Assert.assertTrue(optRepo.parse(MessageFormattingStrategy.class,
+        CustomLineFormat.class.getName()) instanceof MessageFormattingStrategy);
     Assert.assertTrue(optRepo.parse(Pattern.class,
         "somepattern") instanceof Pattern);
 


### PR DESCRIPTION
This change adds `com.p6spy.engine.spy.appender.CustomLineFormat` log message format, which allows the users to specify the layout of the log message via the new configuration attribute `customLogMessageFormat`. 

The benefit of this solution is that no custom code is required to refine log message format. This is especially useful e.g. if p6spy is used by support / operations personnel to troubleshoot connection.