### PR TITLE
Fix %(connectionId) not replaced in custom format

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
@@ -62,7 +62,7 @@ public class CustomLineFormat implements MessageFormattingStrategy {
     }
 
     return customLogMessageFormat
-      .replace(Pattern.quote(CONNECTION_ID), Integer.toString(connectionId))
+      .replaceAll(Pattern.quote(CONNECTION_ID), Integer.toString(connectionId))
       .replaceAll(Pattern.quote(CURRENT_TIME), now)
       .replaceAll(Pattern.quote(EXECUTION_TIME), Long.toString(elapsed))
       .replaceAll(Pattern.quote(CATEGORY), category)


### PR DESCRIPTION
Fix the `spy.log` always has `connection %(connectionId)` but not the actual connection id with the following setting. 

```
logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
customLogMessageFormat=- %(currentTime) | took %(executionTime)ms | connection %(connectionId) \n%(sql)
```