### PR TITLE
chore: maven central sync must-haves

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,22 +211,46 @@ publishing {
         asNode().children().last() + {
           def builder = delegate
 
+          // maven central publishing mandatories
           builder.name project.name
           builder.description description
           builder.url 'https://github.com/p6spy/p6spy'
 
           builder.licenses {
               builder.license {
-                  builder.name 'The Apache Software License, Version 2.0'
-                  builder.url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                  builder.distribution 'repo'
+                builder.name 'The Apache Software License, Version 2.0'
+                builder.url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                builder.distribution 'repo'
+              }
+          }
+          builder.scm {
+              builder.url 'http://github.com/p6spy/p6spy'
+              builder.connection 'scm:git:git://github.com/p6spy/p6spy.git'
+              builder.developerConnection 'scm:git:ssh://github.com:p6spy/p6spy.git'
+          }
+          builder.developers {
+              builder.developer {
+                builder.name 'Quinton McCombs'
+                builder.email 'quinton.mccombs@gmail.com'
+              }
+              builder.developer {
+                builder.name 'Peter Butkovic'
+                builder.email 'butkovic@gmail.com'
+              }
+              builder.developer {
+                builder.name 'Felix Barnsteiner'
+                builder.email 'felix.barnsteiner@isys-software.de'
               }
           }
 
-          builder.scm {
-              builder.url 'scm:git@github.com:p6spy/p6spy.git'
-              builder.connection 'git@github.com:p6spy/p6spy.git'
-              builder.developerConnection 'git@github.com:p6spy/p6spy.git'
+          // maven central publishing optionals
+          builder.issueManagement {
+            builder.system 'github'
+            builder.url 'https://github.com/p6spy/p6spy/issues'
+          }
+          builder.ciManagement {
+            builder.system 'Travis CI'
+            builder.url 'https://travis-ci.org/p6spy/p6spy'
           }
         }
       }


### PR DESCRIPTION
once trying to sync bintray repo with maven central I get: 
> Invalid POM: /p6spy/p6spy/3.1.0/p6spy-3.1.0.pom: Developer information missing Dropping existing partial staging repository. 

let's see if we get any further with this fix