### PR TITLE
refactor: deprecating P6Core, preferring ConnectionWrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
   compileOnly 'ch.qos.logback:logback-classic:1.1.2' 
   compileOnly 'ch.qos.logback:logback-core:1.1.2'
 
-  testCompile 'junit:junit:4.11'
+  testCompile 'junit:junit:4.12'
   testCompile 'org.eclipse.jetty:jetty-plus:8.1.7.v20120910' // datasource testing through JNDI
   testCompile 'commons-dbcp:commons-dbcp:1.4' // datasource testing
   testCompile 'org.codehaus.btm:btm:2.1.4' // xa datasource testing

--- a/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
@@ -40,8 +40,7 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
   private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = //
       ServiceLoader.load(JdbcEventListener.class, DefaultJdbcEventListenerFactory.class.getClassLoader());
   
-  // need to be nulled on reload => keeping protected
-  protected static JdbcEventListener jdbcEventListener;
+  private static JdbcEventListener jdbcEventListener;
   
   @Override
   public JdbcEventListener createJdbcEventListener() {
@@ -58,6 +57,10 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
     }
     
     return jdbcEventListener;
+  }
+  
+  public void clearCache() {
+    jdbcEventListener = null;
   }
   
   protected void registerEventListenersFromFactories(CompoundJdbcEventListener compoundEventListener) {

--- a/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
@@ -1,0 +1,67 @@
+package com.p6spy.engine.spy;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import com.p6spy.engine.event.CompoundJdbcEventListener;
+import com.p6spy.engine.event.DefaultEventListener;
+import com.p6spy.engine.event.JdbcEventListener;
+
+/**
+ * Default {@link JdbcEventListenerFactory} implementation providing all the
+ * {@link JdbcEventListener}s supplied by the {@link P6Factory}ies as well as
+ * those registered by {@link ServiceLoader}s.
+ * 
+ * @author Peter Butkovic
+ * @since 3.3.0
+ *
+ */
+public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory {
+
+  private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = //
+      ServiceLoader.load(JdbcEventListener.class, DefaultJdbcEventListenerFactory.class.getClassLoader());
+  
+  private static JdbcEventListener jdbcEventListener;
+  
+  @Override
+  public JdbcEventListener createJdbcEventListener() {
+    if (jdbcEventListener == null) {
+      synchronized (DefaultJdbcEventListenerFactory.class) {
+        if (jdbcEventListener == null) {
+          CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
+          compoundEventListener.addListender(DefaultEventListener.INSTANCE);
+          registerEventListenersFromFactories(compoundEventListener);
+          registerEventListenersFromServiceLoader(compoundEventListener);
+          jdbcEventListener = compoundEventListener;
+        }
+      }
+    }
+    
+    return jdbcEventListener;
+  }
+  
+  protected void registerEventListenersFromFactories(CompoundJdbcEventListener compoundEventListener) {
+    List<P6Factory> factories = P6ModuleManager.getInstance().getFactories();
+    if (factories != null) {
+      for (P6Factory factory : factories) {
+        final JdbcEventListener eventListener = factory.getJdbcEventListener();
+        if (eventListener != null) {
+          compoundEventListener.addListender(eventListener);
+        }
+      }
+    }
+  }
+
+  protected void registerEventListenersFromServiceLoader(CompoundJdbcEventListener compoundEventListener) {
+    for (Iterator<JdbcEventListener> iterator = jdbcEventListenerServiceLoader.iterator(); iterator.hasNext(); ) {
+      try {
+        compoundEventListener.addListender(iterator.next());
+      } catch (ServiceConfigurationError e) {
+        e.printStackTrace();
+      }
+    }
+  }
+  
+}

--- a/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
@@ -40,7 +40,8 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
   private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = //
       ServiceLoader.load(JdbcEventListener.class, DefaultJdbcEventListenerFactory.class.getClassLoader());
   
-  private static JdbcEventListener jdbcEventListener;
+  // need to be nulled on reload => keeping protected
+  protected static JdbcEventListener jdbcEventListener;
   
   @Override
   public JdbcEventListener createJdbcEventListener() {

--- a/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
@@ -1,3 +1,20 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2017 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.p6spy.engine.spy;
 
 import java.util.Iterator;

--- a/src/main/java/com/p6spy/engine/spy/JdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/JdbcEventListenerFactory.java
@@ -1,0 +1,15 @@
+package com.p6spy.engine.spy;
+
+import com.p6spy.engine.event.JdbcEventListener;
+
+/**
+ * Factory for creating the {@link JdbcEventListener}.
+ * 
+ * @author Peter Butkovic
+ * @since 3.3.0
+ */
+public interface JdbcEventListenerFactory {
+
+  JdbcEventListener createJdbcEventListener();
+  
+}

--- a/src/main/java/com/p6spy/engine/spy/JdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/JdbcEventListenerFactory.java
@@ -1,3 +1,20 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2017 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.p6spy.engine.spy;
 
 import com.p6spy.engine.event.JdbcEventListener;

--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -18,62 +18,30 @@
 
 package com.p6spy.engine.spy;
 
+import java.sql.Connection;
+
 import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.event.CompoundJdbcEventListener;
-import com.p6spy.engine.event.DefaultEventListener;
 import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
-
-import java.sql.Connection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
 
 /**
  * @author Quinton McCombs
  * @since 09/2013
+ * @deprecated use {@link ConnectionWrapper} instead. Should be removed with next major release.
  */
 public class P6Core {
 
-  private static ServiceLoader<JdbcEventListener> jdbcEventListenerServiceLoader = ServiceLoader.load(JdbcEventListener.class, P6Core.class.getClassLoader());
-
-  @Deprecated
+  @SuppressWarnings("resource")
   public static Connection wrapConnection(Connection realConnection, ConnectionInformation connectionInformation) {
     if (realConnection == null) {
       return null;
     }
-    return ConnectionWrapper.wrap(realConnection, getJdbcEventListener(), connectionInformation);
+    return new ConnectionWrapper(realConnection, connectionInformation).wrap();
   }
 
+  @SuppressWarnings("resource")
   public static JdbcEventListener getJdbcEventListener() {
-    CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
-    compoundEventListener.addListender(DefaultEventListener.INSTANCE);
-    registerEventListenersFromFactories(compoundEventListener);
-    registerEventListenersFromServiceLoader(compoundEventListener);
-    return compoundEventListener;
-  }
-
-  private static void registerEventListenersFromFactories(CompoundJdbcEventListener compoundEventListener) {
-    List<P6Factory> factories = P6ModuleManager.getInstance().getFactories();
-    if (factories != null) {
-      for (P6Factory factory : factories) {
-        final JdbcEventListener eventListener = factory.getJdbcEventListener();
-        if (eventListener != null) {
-          compoundEventListener.addListender(eventListener);
-        }
-      }
-    }
-  }
-
-  private static void registerEventListenersFromServiceLoader(CompoundJdbcEventListener compoundEventListener) {
-    for (Iterator<JdbcEventListener> iterator = jdbcEventListenerServiceLoader.iterator(); iterator.hasNext(); ) {
-      try {
-        compoundEventListener.addListender(iterator.next());
-      } catch (ServiceConfigurationError e) {
-        e.printStackTrace();
-      }
-    }
+    return new ConnectionWrapper(null, null).getJdbcEventListener();
   }
 
 }

--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -36,12 +36,11 @@ public class P6Core {
     if (realConnection == null) {
       return null;
     }
-    return new ConnectionWrapper(realConnection, connectionInformation).wrap();
+    return new ConnectionWrapper(realConnection, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), connectionInformation).wrap();
   }
 
-  @SuppressWarnings("resource")
   public static JdbcEventListener getJdbcEventListener() {
-    return new ConnectionWrapper(null, null).getJdbcEventListener();
+    return new DefaultJdbcEventListenerFactory().createJdbcEventListener();
   }
 
 }

--- a/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
+++ b/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
@@ -63,6 +63,13 @@ public class P6ModuleManager {
     try {
       cleanUp();
 
+      new DefaultJdbcEventListenerFactory() {
+        {
+          // we need proper reload of the jdbcEventListener
+          jdbcEventListener = null;
+        }
+      };
+      
       instance = new P6ModuleManager();
       P6LogQuery.initialize();
       

--- a/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
+++ b/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
@@ -62,13 +62,6 @@ public class P6ModuleManager {
   private synchronized static void initMe() {
     try {
       cleanUp();
-
-      new DefaultJdbcEventListenerFactory() {
-        {
-          // we need proper reload of the jdbcEventListener
-          jdbcEventListener = null;
-        }
-      };
       
       instance = new P6ModuleManager();
       P6LogQuery.initialize();
@@ -102,6 +95,9 @@ public class P6ModuleManager {
         instance.mBeansRegistry.unregisterAllMBeans(P6SpyOptions.getActiveInstance().getJmxPrefix());
       }
     }
+    
+    // clean table plz (we need to make sure that all the configured factories will be re-loaded)
+    new DefaultJdbcEventListenerFactory().clearCache();
   }
 
   /**

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -93,8 +93,6 @@ public class P6SpyDriver implements Driver {
 
     P6LogQuery.debug("this is " + this + " and passthru is " + passThru);
 
-    
-    
     final long start = System.nanoTime();
     final Connection conn;
     try {
@@ -106,7 +104,7 @@ public class P6SpyDriver implements Driver {
       throw e;
     }
     
-    ConnectionInformation connectionInformation = ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start);ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start);
+    ConnectionInformation connectionInformation = ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start);
     @SuppressWarnings("resource")
     ConnectionWrapper connectionWrapper = new ConnectionWrapper(conn, connectionInformation);
     connectionWrapper.getJdbcEventListener().onAfterGetConnection(connectionInformation, null);

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -18,11 +18,6 @@
 
 package com.p6spy.engine.spy;
 
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.event.JdbcEventListener;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
-
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -34,6 +29,10 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 /**
  * JDBC driver for P6Spy
@@ -49,14 +48,9 @@ public class P6SpyDriver implements Driver {
     }
   }
 
-
   @Override
-  public boolean acceptsURL(final String url) throws SQLException {
-    if (url != null && url.startsWith("jdbc:p6spy:")) {
-      return true;
-    } else {
-      return false;
-    }
+  public boolean acceptsURL(final String url) {
+    return url != null && url.startsWith("jdbc:p6spy:");
   }
 
   /**
@@ -66,7 +60,7 @@ public class P6SpyDriver implements Driver {
    * @return the parsed URL
    */
   private String extractRealUrl(String url) {
-    return url.startsWith("jdbc:p6spy:") ? url.replace("p6spy:", "") : url;
+    return acceptsURL(url) ? url.replace("p6spy:", "") : url;
   }
 
   static List<Driver> registeredDrivers() {

--- a/src/main/java/com/p6spy/engine/spy/P6XAConnection.java
+++ b/src/main/java/com/p6spy/engine/spy/P6XAConnection.java
@@ -26,8 +26,8 @@ import javax.transaction.xa.XAResource;
 
 public class P6XAConnection extends P6PooledConnection implements XAConnection {
 
-  public P6XAConnection(PooledConnection connection) {
-    super(connection);
+  public P6XAConnection(PooledConnection connection, JdbcEventListenerFactory jdbcEventListenerFactory) {
+    super(connection, jdbcEventListenerFactory);
     
     if (!(connection instanceof XAConnection)) {
       throw new IllegalArgumentException("Argument is supposed to be of type XAConnection, but is rather:" + connection);

--- a/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
@@ -33,6 +33,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -114,9 +115,9 @@ public class ConnectionWrapper extends AbstractWrapper implements Connection {
   }
 
   private void registerEventListenersFromServiceLoader(CompoundJdbcEventListener compoundEventListener) {
-    for (JdbcEventListener jdbcEventListeners : jdbcEventListenerServiceLoader) {
+    for (Iterator<JdbcEventListener> iterator = jdbcEventListenerServiceLoader.iterator(); iterator.hasNext(); ) {
       try {
-        compoundEventListener.addListender(jdbcEventListeners);
+        compoundEventListener.addListender(iterator.next());
       } catch (ServiceConfigurationError e) {
         e.printStackTrace();
       }

--- a/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
@@ -40,22 +40,26 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromProxy() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
-
-    // if the proxy implements the interface then true should be returned.
-    assertTrue(proxy.isWrapperFor(Connection.class));
-    assertTrue(proxy.isWrapperFor(TestConnection.class));
-    assertTrue(proxy.isWrapperFor(Wrapper.class));
+    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
+      Connection proxy = connectionWrapper.wrap();
+  
+      // if the proxy implements the interface then true should be returned.
+      assertTrue(proxy.isWrapperFor(Connection.class));
+      assertTrue(proxy.isWrapperFor(TestConnection.class));
+      assertTrue(proxy.isWrapperFor(Wrapper.class));
+    }
   }
 
   @Test
   public void testCastableFromUnderlying() throws SQLException {
     Connection con = new TestConnectionImpl();
-    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
-
-    // if the underlying object extends the class (or matches the class) then true should be returned.
-    assertTrue(proxy.isWrapperFor(TestConnectionImpl.class));
-    assertTrue(proxy.isWrapperFor(AbstractTestConnection.class));
+    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
+      Connection proxy = connectionWrapper.wrap();
+  
+      // if the underlying object extends the class (or matches the class) then true should be returned.
+      assertTrue(proxy.isWrapperFor(TestConnectionImpl.class));
+      assertTrue(proxy.isWrapperFor(AbstractTestConnection.class));
+    }
   }
 
   @Test
@@ -68,14 +72,15 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
     // is implemented here.
     DelegatingConnection underlying = new DelegatingConnection(con);
 
-    Connection proxy = ConnectionWrapper.wrap(underlying, noOpEventListener, ConnectionInformation.fromTestConnection(con));
+    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
+      Connection proxy = connectionWrapper.wrap();
 
-    // TestConnection is an interface of the wrapped underlying object.
-    assertTrue(proxy.isWrapperFor(TestConnection.class));
-
-    // ResultSet is not implemented at all - false should be returned
-    assertFalse(proxy.isWrapperFor(ResultSet.class));
-
+      // TestConnection is an interface of the wrapped underlying object.
+      assertTrue(proxy.isWrapperFor(TestConnection.class));
+  
+      // ResultSet is not implemented at all - false should be returned
+      assertFalse(proxy.isWrapperFor(ResultSet.class));
+    }
   }
 
 }

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -125,7 +125,9 @@ public class CompoundJdbcEventListenerTest {
     preparedStatementInformation = new PreparedStatementInformation(connectionInformation, "SELECT * FROM DUAL");
     callableStatementInformation = new CallableStatementInformation(connectionInformation, "SELECT * FROM DUAL");
 
-    wrappedConnection = ConnectionWrapper.wrap(mockedConnection, mockedJdbcListener, connectionInformation);
+    @SuppressWarnings("resource")
+    ConnectionWrapper connectionWrapper = new ConnectionWrapper(mockedConnection, mockedJdbcListener, connectionInformation);
+    wrappedConnection = connectionWrapper.wrap();
     verify(mockedJdbcListener).onConnectionWrapped(eq(connectionInformation));
     wrappedStatement = StatementWrapper.wrap(mockedStatement, statementInformation, mockedJdbcListener);
     wrappedPreparedStatement = PreparedStatementWrapper.wrap(mockedPreparedStatement, preparedStatementInformation,

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -52,6 +52,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 
+import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
 import com.p6spy.engine.spy.P6DataSource;
 import com.p6spy.engine.spy.P6PooledConnection;
 import com.p6spy.engine.test.P6TestFactory;
@@ -115,7 +116,7 @@ public class CompoundJdbcEventListenerTest {
     final CallableStatement mockedCallableStatement = mock(CallableStatement.class);
 
     wrappedDataSource = new P6DataSource(mockedDataSource);
-    wrappedPooledConnection = new P6PooledConnection(mockedPooledConnection);
+    wrappedPooledConnection = new P6PooledConnection(mockedPooledConnection, new DefaultJdbcEventListenerFactory());
     when(mockedDataSource.getConnection()).thenReturn(mockedConnection);
     when(mockedDataSource.getConnection(anyString(), anyString())).thenReturn(mockedConnection);
     when(mockedPooledConnection.getConnection()).thenReturn(mockedConnection);

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -18,27 +18,28 @@
 
 package com.p6spy.engine.event;
 
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.logging.LoggingEventListener;
-import com.p6spy.engine.spy.P6Core;
-import com.p6spy.engine.test.TestJdbcEventListener;
-import com.p6spy.engine.test.TestLoggingEventListener;
-
-import com.p6spy.engine.wrapper.ConnectionWrapper;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.sql.Connection;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import org.junit.Test;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.logging.LoggingEventListener;
+import com.p6spy.engine.test.TestJdbcEventListener;
+import com.p6spy.engine.test.TestLoggingEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 public class EventListenerServiceLoaderTest {
 
   @Test
   public void testServiceLoader() throws Exception {
-    JdbcEventListener eventListener = P6Core.getJdbcEventListener();
+    @SuppressWarnings("resource")
+    ConnectionWrapper connectionWrapper = new ConnectionWrapper(null, null);
+    JdbcEventListener eventListener = connectionWrapper.getEventListener();
     assertTrue(eventListener instanceof CompoundJdbcEventListener);
 
     CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) eventListener;

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
+import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
 import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
@@ -37,9 +38,7 @@ public class EventListenerServiceLoaderTest {
 
   @Test
   public void testServiceLoader() throws Exception {
-    @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(null, null);
-    JdbcEventListener eventListener = connectionWrapper.getEventListener();
+    JdbcEventListener eventListener = new DefaultJdbcEventListenerFactory().createJdbcEventListener();
     assertTrue(eventListener instanceof CompoundJdbcEventListener);
 
     CompoundJdbcEventListener compoundJdbcEventListener = (CompoundJdbcEventListener) eventListener;
@@ -55,7 +54,7 @@ public class EventListenerServiceLoaderTest {
   public void testServiceLoaderFromWrapConnection() throws Exception {
     final Connection connectionMock = mock(Connection.class);
     @SuppressWarnings("resource")
-    final Connection connection = new ConnectionWrapper(connectionMock, ConnectionInformation.fromTestConnection(connectionMock)).wrap();
+    final Connection connection = new ConnectionWrapper(connectionMock, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), ConnectionInformation.fromTestConnection(connectionMock)).wrap();
     assertTrue(connection instanceof ConnectionWrapper);
     ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
     final JdbcEventListener eventListener = connectionWrapper.getEventListener();

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -53,7 +53,8 @@ public class EventListenerServiceLoaderTest {
   @Test
   public void testServiceLoaderFromWrapConnection() throws Exception {
     final Connection connectionMock = mock(Connection.class);
-    final Connection connection = P6Core.wrapConnection(connectionMock, ConnectionInformation.fromTestConnection(connectionMock));
+    @SuppressWarnings("resource")
+    final Connection connection = new ConnectionWrapper(connectionMock, ConnectionInformation.fromTestConnection(connectionMock)).wrap();
     assertTrue(connection instanceof ConnectionWrapper);
     ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
     final JdbcEventListener eventListener = connectionWrapper.getEventListener();

--- a/src/test/java/com/p6spy/engine/test/P6TestFramework.java
+++ b/src/test/java/com/p6spy/engine/test/P6TestFramework.java
@@ -95,11 +95,7 @@ public abstract class P6TestFramework extends BaseTestCase {
   @Before
   public void setUpFramework() throws Exception {
     // clean table plz (we need to make sure that all the configured factories will be re-loaded)
-    new DefaultJdbcEventListenerFactory() {
-      {
-        jdbcEventListener = null;
-      }
-    };
+    new DefaultJdbcEventListenerFactory().clearCache();
     
     
     Collection<String> driverNames = P6SpyOptions.getActiveInstance().getDriverNames();

--- a/src/test/java/com/p6spy/engine/test/P6TestFramework.java
+++ b/src/test/java/com/p6spy/engine/test/P6TestFramework.java
@@ -18,30 +18,32 @@
 
 package com.p6spy.engine.test;
 
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.common.P6Util;
-import com.p6spy.engine.spy.P6ModuleManager;
-import com.p6spy.engine.spy.P6SpyOptions;
-import com.p6spy.engine.spy.P6TestUtil;
-import com.p6spy.engine.spy.appender.P6TestLogger;
-import com.p6spy.engine.spy.option.SpyDotProperties;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
-
-import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runners.Parameterized.Parameters;
-
 import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
+import com.p6spy.engine.spy.P6ModuleManager;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.P6TestUtil;
+import com.p6spy.engine.spy.appender.P6TestLogger;
+import com.p6spy.engine.spy.option.SpyDotProperties;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 /**
  * Base test case for tests which should execute against all databases defined for testing.
@@ -92,6 +94,14 @@ public abstract class P6TestFramework extends BaseTestCase {
 
   @Before
   public void setUpFramework() throws Exception {
+    // clean table plz (we need to make sure that all the configured factories will be re-loaded)
+    new DefaultJdbcEventListenerFactory() {
+      {
+        jdbcEventListener = null;
+      }
+    };
+    
+    
     Collection<String> driverNames = P6SpyOptions.getActiveInstance().getDriverNames();
     String user = P6TestOptions.getActiveInstance().getUser();
     String password = P6TestOptions.getActiveInstance().getPassword();

--- a/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
+++ b/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
@@ -38,13 +38,23 @@ public class ConnectionWrapperTest {
   @Test
   public void testOnConnectionWrapped() throws Exception {
     final Connection connection = mock(Connection.class);
-    ConnectionWrapper.wrap(connection, new JdbcEventListener() {
-      @Override
-      public void onConnectionWrapped(ConnectionInformation connectionInformation) {
-        onConnectionWrappedCalled = true;
-        assertEquals(42, connectionInformation.getTimeToGetConnectionNs());
-      }
-    }, ConnectionInformation.fromDataSource(mock(DataSource.class), connection, 42));
-    assertTrue(onConnectionWrappedCalled);
+    try (ConnectionWrapper connectionWrapper = //
+        new ConnectionWrapper( //
+            connection, //
+            new JdbcEventListener() {
+              @Override
+              public void onConnectionWrapped(ConnectionInformation connectionInformation) {
+                onConnectionWrappedCalled = true;
+                assertEquals(42, connectionInformation.getTimeToGetConnectionNs());
+              }
+            }, //
+            ConnectionInformation.fromDataSource( //
+                mock(DataSource.class), // 
+                connection, //
+                42))
+        ) {
+      connectionWrapper.wrap();
+      assertTrue(onConnectionWrappedCalled);
+    }
   }
 }


### PR DESCRIPTION
after reviewing the last PR #384, I believe, we don't need `P6Core` any more and should live with `ConnectionWrapper` only ( => deprecating `P6Core` for now). This also goes a bit in direction of a request in: #118 (less static vars)