### PR TITLE
Make p6spy Java 6 compatible again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,16 @@ repositories {
     }
 }
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+compileJava {
+  sourceCompatibility = 1.6
+  targetCompatibility = 1.6
+}
+
+compileTestJava {
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+}
+
 compileJava.options.encoding = 'UTF8'
 javadoc.options.encoding = 'UTF8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ repositories {
     }
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 compileJava.options.encoding = 'UTF8'
 javadoc.options.encoding = 'UTF8'
 


### PR DESCRIPTION
Was there any particular reason to drop the Java 6 support? Seems to work just fine when changing the compatibility to 1.6.