### PR TITLE
Reintroduce ConnectionWrapper.wrap

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -18,11 +18,11 @@
 
 package com.p6spy.engine.spy;
 
-import java.sql.Connection;
-
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
+
+import java.sql.Connection;
 
 /**
  * @author Quinton McCombs
@@ -36,7 +36,7 @@ public class P6Core {
     if (realConnection == null) {
       return null;
     }
-    return new ConnectionWrapper(realConnection, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), connectionInformation).wrap();
+    return ConnectionWrapper.wrap(realConnection, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), connectionInformation);
   }
 
   public static JdbcEventListener getJdbcEventListener() {

--- a/src/main/java/com/p6spy/engine/spy/P6Core.java
+++ b/src/main/java/com/p6spy/engine/spy/P6Core.java
@@ -18,11 +18,11 @@
 
 package com.p6spy.engine.spy;
 
+import java.sql.Connection;
+
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
-
-import java.sql.Connection;
 
 /**
  * @author Quinton McCombs

--- a/src/main/java/com/p6spy/engine/spy/P6DataSource.java
+++ b/src/main/java/com/p6spy/engine/spy/P6DataSource.java
@@ -45,6 +45,7 @@ import javax.sql.XADataSource;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 /**
@@ -294,18 +295,19 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     }
     
     final Connection conn;
+    final JdbcEventListener jdbcEventListener = this.jdbcEventListenerFactory.createJdbcEventListener();
     try {
       conn = ((DataSource) realDataSource).getConnection();
     } catch (SQLException e) {
-      this.jdbcEventListenerFactory.createJdbcEventListener().onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
       throw e;
     }
     
     ConnectionInformation connectionInformation = ConnectionInformation.fromDataSource(realDataSource, conn, System.nanoTime() - start);
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(conn, this.jdbcEventListenerFactory.createJdbcEventListener(), connectionInformation);
-    connectionWrapper.getJdbcEventListener().onAfterGetConnection(connectionInformation, null);
-    return connectionWrapper.wrap();
+    Connection connectionWrapper = ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+    return connectionWrapper;
   }
   
   @Override
@@ -321,18 +323,19 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     }
     
     final Connection conn;
+    final JdbcEventListener jdbcEventListener = this.jdbcEventListenerFactory.createJdbcEventListener();
     try {
       conn = ((DataSource) realDataSource).getConnection(username, password);
     } catch (SQLException e) {
-      this.jdbcEventListenerFactory.createJdbcEventListener().onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDataSource(realDataSource, null, System.nanoTime() - start), e);
       throw e;
     }
     
     ConnectionInformation connectionInformation = ConnectionInformation.fromDataSource(realDataSource, conn, System.nanoTime() - start);
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(conn, this.jdbcEventListenerFactory.createJdbcEventListener(), connectionInformation);
-    connectionWrapper.getJdbcEventListener().onAfterGetConnection(connectionInformation, null);
-    return connectionWrapper.wrap();
+    Connection connectionWrapper = ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+    return connectionWrapper;
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
+++ b/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
@@ -18,21 +18,21 @@
 
 package com.p6spy.engine.spy;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.StatementEventListener;
-
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public class P6PooledConnection implements PooledConnection {
 
   protected final PooledConnection passthru;
   protected final JdbcEventListenerFactory jdbcEventListenerFactory;
-  
+
   public P6PooledConnection(PooledConnection connection, JdbcEventListenerFactory jdbcEventListenerFactory) {
     this.passthru = connection;
     this.jdbcEventListenerFactory = jdbcEventListenerFactory;
@@ -41,20 +41,21 @@ public class P6PooledConnection implements PooledConnection {
   @Override
   public Connection getConnection() throws SQLException {
     final long start = System.nanoTime();
-    
+
     final Connection conn;
+    final JdbcEventListener jdbcEventListener = this.jdbcEventListenerFactory.createJdbcEventListener();
     try {
       conn = passthru.getConnection();
     } catch (SQLException e) {
-      this.jdbcEventListenerFactory.createJdbcEventListener().onAfterGetConnection(ConnectionInformation.fromPooledConnection(passthru, null, System.nanoTime() - start), e);
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromPooledConnection(passthru, null, System.nanoTime() - start), e);
       throw e;
     }
-    
+
     ConnectionInformation connectionInformation = ConnectionInformation.fromPooledConnection(passthru, conn, System.nanoTime() - start);
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(conn, this.jdbcEventListenerFactory.createJdbcEventListener(), connectionInformation);
-    connectionWrapper.getJdbcEventListener().onAfterGetConnection(connectionInformation, null);
-    return connectionWrapper.wrap();
+    Connection connectionWrapper = ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+    return connectionWrapper;
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
+++ b/src/main/java/com/p6spy/engine/spy/P6PooledConnection.java
@@ -18,15 +18,16 @@
 
 package com.p6spy.engine.spy;
 
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.event.JdbcEventListener;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.StatementEventListener;
-import java.sql.Connection;
-import java.sql.SQLException;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 public class P6PooledConnection implements PooledConnection {
 

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -18,17 +18,22 @@
 
 package com.p6spy.engine.spy;
 
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.event.JdbcEventListener;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
-
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 /**
  * JDBC driver for P6Spy

--- a/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyDriver.java
@@ -18,21 +18,17 @@
 
 package com.p6spy.engine.spy;
 
-import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.wrapper.ConnectionWrapper;
+
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
-
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 /**
  * JDBC driver for P6Spy
@@ -40,7 +36,7 @@ import com.p6spy.engine.wrapper.ConnectionWrapper;
 public class P6SpyDriver implements Driver {
   private static Driver INSTANCE = new P6SpyDriver();
   private static JdbcEventListenerFactory jdbcEventListenerFactory;
-  
+
   static {
     try {
       DriverManager.registerDriver(P6SpyDriver.INSTANCE);
@@ -89,24 +85,25 @@ public class P6SpyDriver implements Driver {
     P6LogQuery.debug("this is " + this + " and passthru is " + passThru);
 
     final long start = System.nanoTime();
-    
+
     if (P6SpyDriver.jdbcEventListenerFactory == null) {
       P6SpyDriver.jdbcEventListenerFactory = new DefaultJdbcEventListenerFactory();
     }
-    
+
     final Connection conn;
+    final JdbcEventListener jdbcEventListener = P6SpyDriver.jdbcEventListenerFactory.createJdbcEventListener();
     try {
       conn =  passThru.connect(extractRealUrl(url), properties);
     } catch (SQLException e) {
-      P6SpyDriver.jdbcEventListenerFactory.createJdbcEventListener().onAfterGetConnection(ConnectionInformation.fromDriver(passThru, null, System.nanoTime() - start), e);
+      jdbcEventListener.onAfterGetConnection(ConnectionInformation.fromDriver(passThru, null, System.nanoTime() - start), e);
       throw e;
     }
-    
+
     ConnectionInformation connectionInformation = ConnectionInformation.fromDriver(passThru, conn, System.nanoTime() - start);
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(conn, P6SpyDriver.jdbcEventListenerFactory.createJdbcEventListener(), connectionInformation);
-    connectionWrapper.getJdbcEventListener().onAfterGetConnection(connectionInformation, null);
-    return connectionWrapper.wrap();
+    Connection connectionWrapper = ConnectionWrapper.wrap(conn, jdbcEventListener, connectionInformation);
+    jdbcEventListener.onAfterGetConnection(connectionInformation, null);
+    return connectionWrapper;
   }
 
   protected Driver findPassthru(String url) throws SQLException {

--- a/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
@@ -40,9 +40,7 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromProxy() throws SQLException {
     Connection con = new TestConnectionImpl();
-    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
-      Connection proxy = connectionWrapper.wrap();
-  
+    try (Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
       // if the proxy implements the interface then true should be returned.
       assertTrue(proxy.isWrapperFor(Connection.class));
       assertTrue(proxy.isWrapperFor(TestConnection.class));
@@ -53,9 +51,7 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromUnderlying() throws SQLException {
     Connection con = new TestConnectionImpl();
-    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
-      Connection proxy = connectionWrapper.wrap();
-  
+    try (Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
       // if the underlying object extends the class (or matches the class) then true should be returned.
       assertTrue(proxy.isWrapperFor(TestConnectionImpl.class));
       assertTrue(proxy.isWrapperFor(AbstractTestConnection.class));
@@ -72,9 +68,7 @@ public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
     // is implemented here.
     DelegatingConnection underlying = new DelegatingConnection(con);
 
-    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
-      Connection proxy = connectionWrapper.wrap();
-
+    try (Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
       // TestConnection is an interface of the wrapped underlying object.
       assertTrue(proxy.isWrapperFor(TestConnection.class));
   

--- a/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
@@ -18,6 +18,15 @@
 
 package com.p6spy.engine.common;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Wrapper;
+
 import com.p6spy.engine.test.AbstractTestConnection;
 import com.p6spy.engine.test.BaseTestCase;
 import com.p6spy.engine.test.TestConnection;
@@ -26,13 +35,6 @@ import com.p6spy.engine.wrapper.AbstractWrapper;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.apache.commons.dbcp.DelegatingConnection;
 import org.junit.Test;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Wrapper;
-
-import static org.junit.Assert.*;
 
 public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
 

--- a/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
@@ -18,15 +18,6 @@
 
 package com.p6spy.engine.common;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Wrapper;
-
 import com.p6spy.engine.test.AbstractTestConnection;
 import com.p6spy.engine.test.BaseTestCase;
 import com.p6spy.engine.test.TestConnection;
@@ -36,15 +27,20 @@ import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.apache.commons.dbcp.DelegatingConnection;
 import org.junit.Test;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Wrapper;
+
+import static org.junit.Assert.*;
+
 public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
 
   @Test
   public void testCastableFromProxy() throws SQLException {
     Connection con = new TestConnectionImpl();
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
-    Connection proxy = connectionWrapper.wrap();
-
+    Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con));
     // if the proxy implements the interface then the proxy should be returned
     {
       Connection unwrapped = proxy.unwrap(Connection.class);
@@ -72,9 +68,7 @@ public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
   @Test
   public void testCastableFromUnderlying() throws SQLException {
     Connection con = new TestConnectionImpl();
-    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
-      Connection proxy = connectionWrapper.wrap();
-
+    try (Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(con))) {
       // if the underlying object extends the class (or matches the class) then the underlying object should be returned.
       {
         AbstractTestConnection unwrapped = proxy.unwrap(AbstractTestConnection.class);
@@ -98,9 +92,7 @@ public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
     // is implemented here.
     DelegatingConnection underlying = new DelegatingConnection(con);
 
-    try (ConnectionWrapper connectionWrapper = new ConnectionWrapper(con, noOpEventListener, ConnectionInformation.fromTestConnection(underlying))) {
-      Connection proxy = connectionWrapper.wrap();
-
+    try (Connection proxy = ConnectionWrapper.wrap(con, noOpEventListener, ConnectionInformation.fromTestConnection(underlying))) {
       // TestConnection is an interface of the actual connection but not of the proxy.  Unwrapping works
       // but a proxy is not returned
       {

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -17,6 +17,44 @@
  */
 package com.p6spy.engine.event;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.Ref;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+
 import com.p6spy.engine.common.CallableStatementInformation;
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.PreparedStatementInformation;
@@ -40,25 +78,6 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.sql.DataSource;
-import javax.sql.PooledConnection;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.math.BigDecimal;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.sql.*;
-import java.util.Calendar;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CompoundJdbcEventListenerTest {

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -17,54 +17,6 @@
  */
 package com.p6spy.engine.event;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.math.BigDecimal;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.sql.Array;
-import java.sql.Blob;
-import java.sql.CallableStatement;
-import java.sql.Clob;
-import java.sql.Connection;
-import java.sql.Date;
-import java.sql.DriverManager;
-import java.sql.NClob;
-import java.sql.PreparedStatement;
-import java.sql.Ref;
-import java.sql.RowId;
-import java.sql.SQLException;
-import java.sql.SQLXML;
-import java.sql.Statement;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.Calendar;
-
-import javax.sql.DataSource;
-import javax.sql.PooledConnection;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatcher;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import com.p6spy.engine.common.CallableStatementInformation;
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.PreparedStatementInformation;
@@ -79,6 +31,34 @@ import com.p6spy.engine.wrapper.CallableStatementWrapper;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 import com.p6spy.engine.wrapper.PreparedStatementWrapper;
 import com.p6spy.engine.wrapper.StatementWrapper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CompoundJdbcEventListenerTest {
@@ -139,8 +119,8 @@ public class CompoundJdbcEventListenerTest {
     callableStatementInformation = new CallableStatementInformation(connectionInformation, "SELECT * FROM DUAL");
 
     @SuppressWarnings("resource")
-    ConnectionWrapper connectionWrapper = new ConnectionWrapper(mockedConnection, mockedJdbcListener, connectionInformation);
-    wrappedConnection = connectionWrapper.wrap();
+    Connection connectionWrapper = ConnectionWrapper.wrap(mockedConnection, mockedJdbcListener, connectionInformation);
+    wrappedConnection = connectionWrapper;
     verify(mockedJdbcListener).onConnectionWrapped(eq(connectionInformation));
     wrappedStatement = StatementWrapper.wrap(mockedStatement, statementInformation, mockedJdbcListener);
     wrappedPreparedStatement = PreparedStatementWrapper.wrap(mockedPreparedStatement, preparedStatementInformation,

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -18,21 +18,20 @@
 
 package com.p6spy.engine.event;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-
-import java.sql.Connection;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
 import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
 import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class EventListenerServiceLoaderTest {
 
@@ -54,7 +53,7 @@ public class EventListenerServiceLoaderTest {
   public void testServiceLoaderFromWrapConnection() throws Exception {
     final Connection connectionMock = mock(Connection.class);
     @SuppressWarnings("resource")
-    final Connection connection = new ConnectionWrapper(connectionMock, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), ConnectionInformation.fromTestConnection(connectionMock)).wrap();
+    final Connection connection = ConnectionWrapper.wrap(connectionMock, new DefaultJdbcEventListenerFactory().createJdbcEventListener(), ConnectionInformation.fromTestConnection(connectionMock));
     assertTrue(connection instanceof ConnectionWrapper);
     ConnectionWrapper connectionWrapper = (ConnectionWrapper) connection;
     final JdbcEventListener eventListener = connectionWrapper.getEventListener();

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -18,6 +18,13 @@
 
 package com.p6spy.engine.event;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+import java.util.List;
+
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
 import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
@@ -25,13 +32,6 @@ import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.junit.Test;
-
-import java.sql.Connection;
-import java.util.List;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class EventListenerServiceLoaderTest {
 

--- a/src/test/java/com/p6spy/engine/spy/P6TestPool.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestPool.java
@@ -17,6 +17,14 @@
  */
 package com.p6spy.engine.spy;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.StatementInformation;
 import com.p6spy.engine.event.SimpleJdbcEventListener;
@@ -27,14 +35,6 @@ import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class P6TestPool extends P6TestFramework {

--- a/src/test/java/com/p6spy/engine/spy/P6TestPool.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestPool.java
@@ -17,27 +17,24 @@
  */
 package com.p6spy.engine.spy;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.common.StatementInformation;
-import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.event.SimpleJdbcEventListener;
 import com.p6spy.engine.test.P6TestFramework;
 import com.p6spy.engine.test.P6TestLoadableOptions;
 import com.p6spy.engine.test.P6TestOptions;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class P6TestPool extends P6TestFramework {
@@ -63,8 +60,8 @@ public class P6TestPool extends P6TestFramework {
   public void testExecute() throws SQLException {
     String query = "select * from customers";
 
-    try (ConnectionWrapper connectionWrapper = //
-        new ConnectionWrapper( //
+    try (Connection connectionWrapper = //
+        ConnectionWrapper.wrap( //
             this.connection, new SimpleJdbcEventListener() {
               @Override
               public void onBeforeAnyExecute(StatementInformation statementInformation) {

--- a/src/test/java/com/p6spy/engine/spy/P6TestStatement.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestStatement.java
@@ -64,8 +64,8 @@ public class P6TestStatement extends P6TestFramework {
   public void testExecuteUpdate() throws SQLException {
     String query = "update customers set name='xyz' where id=1";
     final int[] eventListenerRowCount = { 0 };
-    try (ConnectionWrapper connectionWrapper = //
-        new ConnectionWrapper( //
+    try (Connection connectionWrapper = //
+        ConnectionWrapper.wrap( //
             this.connection, new JdbcEventListener() {
               @Override
               public void onAfterExecuteUpdate(StatementInformation statementInformation, long timeElapsedNanos,
@@ -75,8 +75,7 @@ public class P6TestStatement extends P6TestFramework {
             }, //
             ConnectionInformation.fromTestConnection(this.connection))
         ) {
-      final Connection connectionWrapped = connectionWrapper.wrap();
-      int rowCount = P6TestUtil.executeUpdate(connectionWrapped, query);
+      int rowCount = P6TestUtil.executeUpdate(connectionWrapper, query);
       assertEquals(1, rowCount);
       assertEquals(1, eventListenerRowCount[0]);
 
@@ -94,8 +93,8 @@ public class P6TestStatement extends P6TestFramework {
     P6LogOptions.getActiveInstance().setExcludecategories("");
     // test batch inserts
     final int[] eventListenerUpdateCounts = new int[2];
-    try (ConnectionWrapper connectionWrapper = //
-        new ConnectionWrapper( //
+    try (Connection connectionWrapper = //
+        ConnectionWrapper.wrap( //
             this.connection, new JdbcEventListener() {
               @Override
               public void onAfterExecuteBatch(StatementInformation statementInformation, long timeElapsedNanos,
@@ -105,7 +104,7 @@ public class P6TestStatement extends P6TestFramework {
               }
             }, //
             ConnectionInformation.fromTestConnection(this.connection) //
-        ); Statement stmt = connectionWrapper.wrap().createStatement() //
+        ); Statement stmt = connectionWrapper.createStatement() //
     ) {
       String sql = "insert into customers(name,id) values ('jim', 101)";
       stmt.addBatch(sql);

--- a/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
+++ b/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
@@ -20,12 +20,10 @@ package com.p6spy.engine.wrapper;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.JdbcEventListener;
-
 import org.junit.Test;
 
-import java.sql.Connection;
-
 import javax.sql.DataSource;
+import java.sql.Connection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,8 +36,8 @@ public class ConnectionWrapperTest {
   @Test
   public void testOnConnectionWrapped() throws Exception {
     final Connection connection = mock(Connection.class);
-    try (ConnectionWrapper connectionWrapper = //
-        new ConnectionWrapper( //
+    try (Connection connectionWrapper = //
+        ConnectionWrapper.wrap( //
             connection, //
             new JdbcEventListener() {
               @Override
@@ -53,7 +51,6 @@ public class ConnectionWrapperTest {
                 connection, //
                 42))
         ) {
-      connectionWrapper.wrap();
       assertTrue(onConnectionWrappedCalled);
     }
   }

--- a/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
+++ b/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
@@ -18,16 +18,17 @@
 
 package com.p6spy.engine.wrapper;
 
-import com.p6spy.engine.common.ConnectionInformation;
-import com.p6spy.engine.event.JdbcEventListener;
-import org.junit.Test;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+
+import javax.sql.DataSource;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import org.junit.Test;
 
 public class ConnectionWrapperTest {
 


### PR DESCRIPTION
Fixes a breaking change in #400
Also concerns #401 

PS: We should probably agree on a common formatter or at least import order. Which IDE and formatter are you using? For p6spy, I'm using IntelliJ with default settings apart from indent=2 spaces.