### PR TITLE
fix: CustomLineFormat with dollar sign in statement (fixes #417)

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,10 +1,9 @@
 # Release Notes
 
-## [3.4.1](https://github.com/p6spy/p6spy/compare/p6spy-3.3.0...master) (Unreleased)
-
-Improvements:
+## [3.4.1](https://github.com/p6spy/p6spy/compare/p6spy-3.4.0...master) (Unreleased)
 
 Defects resolved:
+* [issue #417](https://github.com/p6spy/p6spy/pull/417): Fix `IllegalArgumentException` for `CustomLineFormat` with specific chars in statement
 
 ## [3.4.0](https://github.com/p6spy/p6spy/compare/p6spy-3.3.0...3.4.0) (2017-10-13)
 

--- a/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
@@ -18,10 +18,11 @@
 
 package com.p6spy.engine.spy.appender;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.p6spy.engine.common.P6Util;
 import com.p6spy.engine.spy.P6SpyOptions;
-
-import java.util.regex.Pattern;
 
 /**
  * @author Peter G. Horvath
@@ -66,9 +67,9 @@ public class CustomLineFormat implements MessageFormattingStrategy {
       .replaceAll(Pattern.quote(CURRENT_TIME), now)
       .replaceAll(Pattern.quote(EXECUTION_TIME), Long.toString(elapsed))
       .replaceAll(Pattern.quote(CATEGORY), category)
-      .replaceAll(Pattern.quote(EFFECTIVE_SQL), prepared)
-      .replaceAll(Pattern.quote(EFFECTIVE_SQL_SINGLELINE), P6Util.singleLine(prepared))
-      .replaceAll(Pattern.quote(SQL), sql)
-      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), P6Util.singleLine(sql));
+      .replaceAll(Pattern.quote(EFFECTIVE_SQL), Matcher.quoteReplacement(prepared))
+      .replaceAll(Pattern.quote(EFFECTIVE_SQL_SINGLELINE), Matcher.quoteReplacement(P6Util.singleLine(prepared)))
+      .replaceAll(Pattern.quote(SQL), Matcher.quoteReplacement(sql))
+      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), Matcher.quoteReplacement(P6Util.singleLine(sql)));
   }
 }

--- a/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -477,6 +478,22 @@ public class P6TestCommon extends P6TestFramework {
       // reset formatting setting
       P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
     }
+    
+    // prep statement
+    {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomLineFormat.class.getName());
+        P6SpyOptions.getActiveInstance().setCustomLogMessageFormat("%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)\n%(effectiveSqlSingleLine)\n%(sqlSingleLine);\n");
+
+        String query = "select count(*) from customers where name IN (?, ?)";
+        PreparedStatement prep = connection.prepareStatement(query);
+        prep.setString(1, "foo");
+        prep.setString(2, "bar");
+        prep.executeQuery();
+        assertTrue(super.getLastLogEntry().contains("\nselect count(*) from customers where name IN (?, ?)\nselect count(*) from customers where name IN ('foo', 'bar');"));
+
+        // reset formatting setting
+        P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+      }
     {
       P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomLineFormat.class.getName());
       P6SpyOptions.getActiveInstance().setCustomLogMessageFormat("SQL in custom format: #"+

--- a/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
@@ -29,9 +29,9 @@ public class CustomLineFormatTest {
 	@After
 	public void after() {
 		// reset formatting setting
-        P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
 	}
-	
+
 	@Test
 	public void formatPreparedStatementWithDollarSign() {
 		String customLogMessageFormat = "%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)\n%(effectiveSqlSingleLine)\n%(sqlSingleLine);\n";
@@ -39,9 +39,9 @@ public class CustomLineFormatTest {
 		String logMsg = new CustomLineFormat().formatMessage(0, "1", 1L, "statement",
 				"select value from V$parameter where lower(name)=?",
 				"select value from V$parameter where lower(name)='compatible'");
-		
-		Assert.assertTrue(logMsg.contains("select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));
-		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
-	}	
-	
+
+		Assert.assertTrue(logMsg.contains(
+				"select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));
+	}
+
 }

--- a/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
@@ -1,0 +1,47 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2017 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.spy.appender;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+
+import org.junit.Assert;
+
+public class CustomLineFormatTest {
+
+	@After
+	public void after() {
+		// reset formatting setting
+        P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+	}
+	
+	@Test
+	public void formatPreparedStatementWithDollarSign() {
+		String customLogMessageFormat = "%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)\n%(effectiveSqlSingleLine)\n%(sqlSingleLine);\n";
+		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(customLogMessageFormat);
+		String logMsg = new CustomLineFormat().formatMessage(0, "1", 1L, "statement",
+				"select value from V$parameter where lower(name)=?",
+				"select value from V$parameter where lower(name)='compatible'");
+		
+		Assert.assertTrue(logMsg.contains("select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));
+		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
+	}	
+	
+}


### PR DESCRIPTION
fix for the #417 

Fix comes with proper escaping of the 2.nd argument in: `String.replaceAll(String regex, String replacement)`. Solution credit: https://stackoverflow.com/a/45718182/1581069