### PR TITLE
refactor: enum for P6OutageDetector singleton implementation over synchronized blocks (fix #363)

### DIFF
--- a/src/main/java/com/p6spy/engine/outage/OutageJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/outage/OutageJdbcEventListener.java
@@ -37,35 +37,35 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   @Override
   public void onBeforeCommit(ConnectionInformation connectionInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().registerInvocation(this, System.nanoTime(), "commit", "", "");
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "commit", "", "");
     }
   }
 
   @Override
   public void onAfterCommit(ConnectionInformation connectionInformation, long timeElapsedNanos, SQLException e) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().unregisterInvocation(this);
+      P6OutageDetector.INSTANCE.unregisterInvocation(this);
     }
   }
 
   @Override
   public void onBeforeRollback(ConnectionInformation connectionInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().registerInvocation(this, System.nanoTime(), "rollback", "", "");
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "rollback", "", "");
     }
   }
 
   @Override
   public void onAfterRollback(ConnectionInformation connectionInformation, long timeElapsedNanos, SQLException e) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().unregisterInvocation(this);
+      P6OutageDetector.INSTANCE.unregisterInvocation(this);
     }
   }
 
   @Override
   public void onBeforeAnyAddBatch(StatementInformation statementInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().registerInvocation(this, System.nanoTime(), "batch",
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "batch",
         statementInformation.getSqlWithValues(), statementInformation.getStatementQuery());
     }
   }
@@ -73,14 +73,14 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   @Override
   public void onAfterAnyAddBatch(StatementInformation statementInformation, long timeElapsedNanos, SQLException e) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().unregisterInvocation(this);
+      P6OutageDetector.INSTANCE.unregisterInvocation(this);
     }
   }
 
   @Override
   public void onBeforeAnyExecute(StatementInformation statementInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().registerInvocation(this, System.nanoTime(), "statement",
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "statement",
         statementInformation.getSqlWithValues(), statementInformation.getStatementQuery());
     }
   }
@@ -88,7 +88,7 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   @Override
   public void onAfterAnyExecute(StatementInformation statementInformation, long timeElapsedNanos, SQLException e) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.getInstance().unregisterInvocation(this);
+      P6OutageDetector.INSTANCE.unregisterInvocation(this);
     }
   }
 }


### PR DESCRIPTION
#363 reports `NullPointerException` in `OutageJdbcEventListener.onAfterCommit()` where the code says:  

https://github.com/p6spy/p6spy/blob/e020234df4a8ec6e153758b71cc9fe31de47750a/src/main/java/com/p6spy/engine/outage/OutageJdbcEventListener.java#L47

However `P6OutageDetector` seems to be sort of sigleton and `P6OutageDetector.getInstance()` is `synchronized`. So I suspect that the singletion impl is not robust enough and as Enums ensure single instance in java and provide much simpler singleton implementation, I'm taking it.

I believe #363 can be closed afterwards, as no buggy magic in singleton creation would be present.

In fact that also means we break the API, as `P6OutageDetector` won't be extendible in the future, but I doubt people try to extend this dark side of p6spy. And we can still release next major release (3.5.0) and live happily ever after.