### PR TITLE
Adding url logging to loggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ javadocs
 /.idea
 *.iml
 /atlassian-ide-plugin.xml
+/out/*
 
 # vscode
 .vscode

--- a/src/main/assembly/individualFiles/spy.properties
+++ b/src/main/assembly/individualFiles/spy.properties
@@ -109,6 +109,7 @@
 #   %(effectiveSqlSingleLine)  the SQL statement as submitted to the driver, with all new lines removed
 #   %(sql)                     the SQL statement with all bind variables replaced with actual values
 #   %(sqlSingleLine)           the SQL statement with all bind variables replaced with actual values, with all new lines removed
+#   %(url)                     the database url where the sql statement executed
 #customLogMessageFormat=%(currentTime)|%(executionTime)|%(category)|connection%(connectionId)|%(sqlSingleLine)
 
 # format that is used for logging of the date/time/... (has to be compatible with java.text.SimpleDateFormat)

--- a/src/main/java/com/p6spy/engine/common/P6LogQuery.java
+++ b/src/main/java/com/p6spy/engine/common/P6LogQuery.java
@@ -83,12 +83,12 @@ public class P6LogQuery implements P6OptionChangedListener {
   }
 
   static protected void doLog(long elapsed, Category category, String prepared, String sql) {
-    doLog(-1, elapsed, category, prepared, sql);
+    doLog(-1, elapsed, category, prepared, sql, "");
   }
 
   // this is an internal method called by logElapsed
-  static protected void doLogElapsed(int connectionId, long timeElapsedNanos, Category category, String prepared, String sql) {
-    doLog(connectionId, timeElapsedNanos, category, prepared, sql);
+  static protected void doLogElapsed(int connectionId, long timeElapsedNanos, Category category, String prepared, String sql, String url) {
+    doLog(connectionId, timeElapsedNanos, category, prepared, sql, url);
   }
 
 	/**
@@ -99,8 +99,9 @@ public class P6LogQuery implements P6OptionChangedListener {
 	 * @param category
 	 * @param prepared
 	 * @param sql
+   * @param url
 	 */
-	protected static void doLog(int connectionId, long elapsedNanos, Category category, String prepared, String sql) {
+	protected static void doLog(int connectionId, long elapsedNanos, Category category, String prepared, String sql, String url) {
 	    // give it one more try if not initialized yet
 	    if (logger == null) {
 	      initialize();
@@ -117,7 +118,7 @@ public class P6LogQuery implements P6OptionChangedListener {
         stringNow = new SimpleDateFormat(format).format(new java.util.Date()).trim();
       }
 
-      logger.logSQL(connectionId, stringNow, TimeUnit.NANOSECONDS.toMillis(elapsedNanos), category, prepared, sql);
+      logger.logSQL(connectionId, stringNow, TimeUnit.NANOSECONDS.toMillis(elapsedNanos), category, prepared, sql, url);
 
       final boolean stackTrace = P6SpyOptions.getActiveInstance().getStackTrace();
       if (stackTrace) {
@@ -184,9 +185,9 @@ public class P6LogQuery implements P6OptionChangedListener {
     }
   }
 
-  public static void logElapsed(int connectionId, long timeElapsedNanos, Category category, String prepared, String sql) {
+  public static void logElapsed(int connectionId, long timeElapsedNanos, Category category, String prepared, String sql, String url) {
     if (logger != null && meetsThresholdRequirement(timeElapsedNanos) && isCategoryOk(category) && isLoggable(sql) ) {
-      doLogElapsed(connectionId, timeElapsedNanos, category, prepared, sql);
+      doLogElapsed(connectionId, timeElapsedNanos, category, prepared, sql, url == null ? "" : url);
     } else if (isDebugEnabled()) {
       debug("P6Spy intentionally did not log category: " + category + ", statement: " + sql + "  Reason: logger=" + logger + ", isLoggable="
           + isLoggable(sql) + ", isCategoryOk=" + isCategoryOk(category) + ", meetsTreshold=" + meetsThresholdRequirement(timeElapsedNanos));
@@ -196,8 +197,9 @@ public class P6LogQuery implements P6OptionChangedListener {
   public static void logElapsed(int connectionId, long timeElapsedNanos, Category category, Loggable loggable) {
     // usually an expensive operation => cache where possible
     String sql;
+    String url = loggable.getConnectionInformation().getUrl();
     if (logger != null && meetsThresholdRequirement(timeElapsedNanos) && isCategoryOk(category) && isLoggable(sql = loggable.getSql())) {
-      doLogElapsed(connectionId, timeElapsedNanos, category, sql, loggable.getSqlWithValues());
+      doLogElapsed(connectionId, timeElapsedNanos, category, sql, loggable.getSqlWithValues(), url == null ? "" : url);
     } else if (isDebugEnabled()) {
       sql = loggable.getSqlWithValues();
       debug("P6Spy intentionally did not log category: " + category + ", statement: " + sql + "  Reason: logger=" + logger + ", isLoggable="

--- a/src/main/java/com/p6spy/engine/outage/OutageJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/outage/OutageJdbcEventListener.java
@@ -36,7 +36,7 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   @Override
   public void onBeforeCommit(ConnectionInformation connectionInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "commit", "", "");
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "commit", "", "", connectionInformation.getUrl());
     }
   }
 
@@ -50,7 +50,7 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   @Override
   public void onBeforeRollback(ConnectionInformation connectionInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
-      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "rollback", "", "");
+      P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "rollback", "", "", connectionInformation.getUrl());
     }
   }
 
@@ -65,7 +65,7 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   public void onBeforeAnyAddBatch(StatementInformation statementInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
       P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "batch",
-        statementInformation.getSqlWithValues(), statementInformation.getStatementQuery());
+        statementInformation.getSqlWithValues(), statementInformation.getStatementQuery(), statementInformation.getConnectionInformation().getUrl());
     }
   }
 
@@ -80,7 +80,7 @@ public class OutageJdbcEventListener extends SimpleJdbcEventListener {
   public void onBeforeAnyExecute(StatementInformation statementInformation) {
     if (P6OutageOptions.getActiveInstance().getOutageDetection()) {
       P6OutageDetector.INSTANCE.registerInvocation(this, System.nanoTime(), "statement",
-        statementInformation.getSqlWithValues(), statementInformation.getStatementQuery());
+        statementInformation.getSqlWithValues(), statementInformation.getStatementQuery(), statementInformation.getConnectionInformation().getUrl());
     }
   }
 

--- a/src/main/java/com/p6spy/engine/outage/P6OutageDetector.java
+++ b/src/main/java/com/p6spy/engine/outage/P6OutageDetector.java
@@ -98,8 +98,8 @@ public enum P6OutageDetector implements Runnable {
      * Registers the execution of a statement. This should be called just before the statement is
      * passed to the real driver.
      */
-    public void registerInvocation(Object jdbcObject, long startTime, String category, String ps, String sql) {
-        pendingMessages.put(jdbcObject, new InvocationInfo(startTime, category, ps, sql));
+    public void registerInvocation(Object jdbcObject, long startTime, String category, String ps, String sql, String url) {
+        pendingMessages.put(jdbcObject, new InvocationInfo(startTime, category, ps, sql, url));
     }
 
     /**
@@ -139,7 +139,7 @@ public enum P6OutageDetector implements Runnable {
     }
 
     private void logOutage(InvocationInfo ii) {
-        P6LogQuery.logElapsed(-1, System.nanoTime() - ii.startTime, Category.OUTAGE, ii.preparedStmt, ii.sql);
+        P6LogQuery.logElapsed(-1, System.nanoTime() - ii.startTime, Category.OUTAGE, ii.preparedStmt, ii.sql, ii.url);
     }
 
 }
@@ -154,10 +154,13 @@ class InvocationInfo {
 
     public String sql;
 
-    public InvocationInfo(long startTime, String category, String ps, String sql) {
+    public String url;
+
+    public InvocationInfo(long startTime, String category, String ps, String sql, String url) {
         this.startTime = startTime;
         this.category = category;
         this.preparedStmt = ps;
         this.sql = sql;
+        this.url = url;
     }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/BatchFileLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/BatchFileLogger.java
@@ -50,7 +50,7 @@ public class BatchFileLogger extends FileLogger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql) {
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
     if (endOfStatement) {
       getStream().println(BATCH_SEPARATOR);
     }

--- a/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
@@ -39,6 +39,7 @@ public class CustomLineFormat implements MessageFormattingStrategy {
   public static final String EFFECTIVE_SQL_SINGLELINE = "%(effectiveSqlSingleLine)";
   public static final String SQL = "%(sql)";
   public static final String SQL_SINGLE_LINE = "%(sqlSingleLine)";
+  public static final String URL = "%(url)";
 
   /**
    * Formats a log message for the logging module
@@ -49,16 +50,17 @@ public class CustomLineFormat implements MessageFormattingStrategy {
    * @param category     the category of the operation
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
+   * @param url          the database url where the sql statement executed
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql) {
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
 
     String customLogMessageFormat = P6SpyOptions.getActiveInstance().getCustomLogMessageFormat();
 
     if (customLogMessageFormat == null) {
       // Someone forgot to configure customLogMessageFormat: fall back to built-in
-      return FALLBACK_FORMATTING_STRATEGY.formatMessage(connectionId, now, elapsed, category, prepared, sql);
+      return FALLBACK_FORMATTING_STRATEGY.formatMessage(connectionId, now, elapsed, category, prepared, sql, url);
     }
 
     return customLogMessageFormat
@@ -69,6 +71,7 @@ public class CustomLineFormat implements MessageFormattingStrategy {
       .replaceAll(Pattern.quote(EFFECTIVE_SQL), Matcher.quoteReplacement(prepared))
       .replaceAll(Pattern.quote(EFFECTIVE_SQL_SINGLELINE), Matcher.quoteReplacement(P6Util.singleLine(prepared)))
       .replaceAll(Pattern.quote(SQL), Matcher.quoteReplacement(sql))
-      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), Matcher.quoteReplacement(P6Util.singleLine(sql)));
+      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), Matcher.quoteReplacement(P6Util.singleLine(sql)))
+      .replaceAll(Pattern.quote(URL), url);
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/FormattedLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/FormattedLogger.java
@@ -31,8 +31,8 @@ public abstract class FormattedLogger implements P6Logger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql) {
-    logText(strategy.formatMessage(connectionId, now, elapsed, category.toString(), prepared, sql));
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
+    logText(strategy.formatMessage(connectionId, now, elapsed, category.toString(), prepared, sql, url));
   }
 
   /**

--- a/src/main/java/com/p6spy/engine/spy/appender/MessageFormattingStrategy.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/MessageFormattingStrategy.java
@@ -31,8 +31,9 @@ public interface MessageFormattingStrategy {
    * @param category the category of the operation
    * @param prepared the SQL statement with all bind variables replaced with actual values
    * @param sql the sql statement executed
+   * @param url the database url where the sql statement executed
    * @return the formatted log message
    */
-  String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql);
+  String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url);
 
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/MultiLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/MultiLineFormat.java
@@ -32,10 +32,11 @@ public class MultiLineFormat implements MessageFormattingStrategy {
    * @param category     the category of the operation
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
+   * @param url          the database url where the sql statement executed
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql) {
-    return "#" + now + " | took " + elapsed + "ms | " + category + " | connection " + connectionId + "|" + prepared + "\n" + sql +";";
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
+    return "#" + now + " | took " + elapsed + "ms | " + category + " | connection " + connectionId + "| url " + url + "\n" + prepared + "\n" + sql +";";
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/P6Logger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/P6Logger.java
@@ -35,9 +35,11 @@ public interface P6Logger {
          *            the prepared statement to be logged.
          * @param sql
          *            the {@code SQL} to be logged.
+         * @param url
+         *            the database url where the sql statement executed
          */
         public void logSQL(int connectionId, String now, long elapsed,
-                        Category category, String prepared, String sql);
+                        Category category, String prepared, String sql, String url);
 
         /**
          * Logs the stacktrace of the exception.

--- a/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
@@ -34,10 +34,11 @@ public class SingleLineFormat implements MessageFormattingStrategy {
    * @param category     the category of the operation
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
+   * @param url          the database url where the sql statement executed
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql) {
-    return now + "|" + elapsed + "|" + category + "|connection " + connectionId + "|" + P6Util.singleLine(prepared) + "|" + P6Util.singleLine(sql);
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
+    return now + "|" + elapsed + "|" + category + "|connection " + connectionId + "|url " + url + "|" + P6Util.singleLine(prepared) + "|" + P6Util.singleLine(sql);
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/Slf4JLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/Slf4JLogger.java
@@ -46,9 +46,9 @@ public class Slf4JLogger extends FormattedLogger {
 
 	@Override
 	public void logSQL(int connectionId, String now, long elapsed,
-			Category category, String prepared, String sql) {
+			Category category, String prepared, String sql, String url) {
 		final String msg = strategy.formatMessage(connectionId, now, elapsed,
-				category.toString(), prepared, sql);
+				category.toString(), prepared, sql, url);
 
 		if (Category.ERROR.equals(category)) {
 			log.error(msg);

--- a/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
@@ -38,7 +38,7 @@ public class CustomLineFormatTest {
 		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(customLogMessageFormat);
 		String logMsg = new CustomLineFormat().formatMessage(0, "1", 1L, "statement",
 				"select value from V$parameter where lower(name)=?",
-				"select value from V$parameter where lower(name)='compatible'");
+				"select value from V$parameter where lower(name)='compatible'", "jdbc:h2:mem:p6spyDSTest");
 
 		Assert.assertTrue(logMsg.contains(
 				"select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));

--- a/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
@@ -48,8 +48,8 @@ public class P6TestLogger extends StdoutLogger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql) {
-    super.logSQL(connectionId, now, elapsed, category, prepared, sql);
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
+    super.logSQL(connectionId, now, elapsed, category, prepared, sql, url);
     times.add(elapsed);
   }
 


### PR DESCRIPTION
Hi P6spy team,

We are working on a multi tenant application and planning to use p6spy to monitor query usages, etc. Our application is talking to multiple back-end data sources and we need the URL to figure out which SQL statements go to which back-end database. In our case the back-end databases have the same schema, so table names aren't enough to tell them apart.

The changes I made passed all the existing test cases and is working for our application. I think this is also an improvement for a previous merged pull request (https://github.com/p6spy/p6spy/pull/440).

Please let me know if you have any questions & suggestions.

Thank you!
Fangming
