### PR TITLE
We know we put 2 chars for each byte in argument of com.p6spy.engine.…

### DIFF
--- a/src/main/java/com/p6spy/engine/common/Value.java
+++ b/src/main/java/com/p6spy/engine/common/Value.java
@@ -123,7 +123,7 @@ public class Value {
    *         {@code bytes}.
    */
   private String toHexString(byte[] bytes) {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
     for (byte b : bytes) {
       int temp = (int) b & 0xFF;
       sb.append(HEX_CHARS[temp / 16]);


### PR DESCRIPTION
We know 2 chars are appended to `StringBuilder` for each byte of array passed into `com.p6spy.engine.common.Value::toHexString`.
This means `StringBuilder` of exact size can be created right away.