### PR TITLE
Get jdbcUrl from Connection when using P6DataSource

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/P6DataSource.java
+++ b/src/main/java/com/p6spy/engine/spy/P6DataSource.java
@@ -301,6 +301,9 @@ public class P6DataSource implements DataSource, ConnectionPoolDataSource, XADat
     try {
       conn = ((DataSource) realDataSource).getConnection();
       connectionInformation.setConnection(conn);
+
+      connectionInformation.setUrl(conn.getMetaData().getURL());
+
       connectionInformation.setTimeToGetConnectionNs(System.nanoTime() - start);
       jdbcEventListener.onAfterGetConnection(connectionInformation, null);
     } catch (SQLException e) {


### PR DESCRIPTION
Fix missing URL when using  P6DataSource