### PR TITLE
Replace StringBuilder with char[] in Value::toHexString

### DIFF
--- a/src/main/java/com/p6spy/engine/common/Value.java
+++ b/src/main/java/com/p6spy/engine/common/Value.java
@@ -126,13 +126,14 @@ public class Value {
    *         {@code bytes}.
    */
   private String toHexString(byte[] bytes) {
-    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    char[] result = new char[bytes.length * 2];
+    int idx = 0;
     for (byte b : bytes) {
       int temp = (int) b & 0xFF;
-      sb.append(HEX_CHARS[temp / 16]);
-      sb.append(HEX_CHARS[temp % 16]);
+      result[idx++] = HEX_CHARS[temp / 16];
+      result[idx++] = HEX_CHARS[temp % 16];
     }
-    return sb.toString();
+    return new String(result);
   }
 
   /**


### PR DESCRIPTION
Further improvement in this method is possible, we don't need to use `StringBuilder` at all as we know exactly how many chars are put into returned String. Instead we can apply `char[]` of exact size. This gives nice improvement, see results for input array of 20 Mb:
```
Benchmark                             Mode  Cnt    Score   Error  Units
SizedStringBuilderBenchmark.original  avgt   30  203,302 ± 9,791  ms/op
SizedStringBuilderBenchmark.patched   avgt   30  180,773 ± 5,190  ms/op
SizedStringBuilderBenchmark.chars     avgt   30   68,756 ± 3,767  ms/op
```

`Original` here is for the code prior to https://github.com/p6spy/p6spy/pull/450
`Patched` stands for current version and `chars` is for the code of this PR.