### PR TITLE
fix: commits/rollbacks are not logged when using include/exclude (#469)

### DIFF
--- a/src/main/java/com/p6spy/engine/common/P6LogQuery.java
+++ b/src/main/java/com/p6spy/engine/common/P6LogQuery.java
@@ -140,10 +140,11 @@ public class P6LogQuery implements P6OptionChangedListener {
   }
 
   static boolean isLoggable(String sql) {
-	if (null == sql) {
-		return false;
-	}
-	
+    // empty batches and connection commits/rollbacks
+    if (sql == null || sql.isEmpty()) {
+      return true;
+    }
+
     final P6LogLoadableOptions opts = P6LogOptions.getActiveInstance();
     
     if (!opts.getFilter()) {

--- a/src/main/java/com/p6spy/engine/logging/P6LogOptions.java
+++ b/src/main/java/com/p6spy/engine/logging/P6LogOptions.java
@@ -109,7 +109,7 @@ public class P6LogOptions extends StandardMBean implements P6LogLoadableOptions 
       return null;
     }
 
-    final StringBuilder sb = new StringBuilder("(?mis)^");
+    final StringBuilder sb = new StringBuilder("(?mis)");
     
     if (excludes.length() > 0 ) {
       sb.append("(?!.*(").append(excludes).append(").*)");
@@ -122,7 +122,7 @@ public class P6LogOptions extends StandardMBean implements P6LogLoadableOptions 
       sb.append("(.*)");
     }
     
-    return sb.append("$").toString();
+    return sb.toString();
   }
   
   @Override

--- a/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestCommon.java
@@ -154,6 +154,28 @@ public class P6TestCommon extends P6TestFramework {
       P6LogOptions.getActiveInstance().setInclude("");
       assertEquals(1, super.getLogEntriesCount());
     }
+
+    // excluded - connection commit  => logged
+    {
+      super.clearLogEntries();
+      P6LogOptions.getActiveInstance().setExclude("customers");
+      connection.setAutoCommit(false);
+      connection.commit();
+      connection.setAutoCommit(true);
+      P6LogOptions.getActiveInstance().setExclude("");
+      assertEquals(1, super.getLogEntriesCount());
+    }
+
+    // included - connection commit  => logged
+    {
+      super.clearLogEntries();
+      P6LogOptions.getActiveInstance().setInclude("customers");
+      connection.setAutoCommit(false);
+      connection.commit();
+      connection.setAutoCommit(true);
+      P6LogOptions.getActiveInstance().setInclude("");
+      assertEquals(1, super.getLogEntriesCount());
+    }
   }
   
   @Test


### PR DESCRIPTION
First I removed `^` and `$` from regexp because it caused the issue, but noticed that if `include` is specified empty string is not allowed as well, which causes commits/rollbacks to not getting logged as well. 
It can cause confusion for users who specified `include=myimportanttable` don't want to see commit/rollback events to be logged, but it should not be implicitly related to connection not having SQL string, but rather explicitly adding it into `excludecategories`. By the same reason I think we should change previous condition:
```
if (null == sql) {
	return false;
}
```
to return true. Initially it was a fix for not having NPE when empty batch is executed - #246, but also resulted in not logging fact that batch was executed, which, I think, should be controlled by category as well.

cc @typekpb / @felixbarny 