### PR TITLE
add events for Connection.setAutoCommit

### DIFF
--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -41,17 +41,19 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
 
 
   /**
-   * adds a listener to this {@link CompoundJdbcEventListener}
-   * @param listener the listener to add
-   * @deprecated this method name has a typo, please use {@link CompoundJdbcEventListener#addListener}
+   * Adds a listener to this {@link CompoundJdbcEventListener}
+   *
+   * @param listener The listener to add
+   * @deprecated     This method name has a typo, please use {@link CompoundJdbcEventListener#addListener}
    */
   public void addListender(JdbcEventListener listener) {
     addListener(listener);
   }
 
   /**
-   * adds a listener to this {@link CompoundJdbcEventListener}
-   * @param listener the listener to add
+   * Adds a listener to this {@link CompoundJdbcEventListener}
+   *
+   * @param listener The listener to add
    */
   public void addListener(JdbcEventListener listener) {
     eventListeners.add(listener);

--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -39,7 +39,7 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
     this.eventListeners = eventListeners;
   }
 
-  public void addListender(JdbcEventListener listener) {
+  public void addListener(JdbcEventListener listener) {
     eventListeners.add(listener);
   }
 
@@ -297,4 +297,19 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
       eventListener.onAfterStatementClose(statementInformation, e);
     }
   }
+
+  @Override
+  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
+    for (JdbcEventListener eventListener : eventListeners) {
+      eventListener.onBeforeSetAutoCommit(connectionInformation, newAutoCommit,oldAutoCommit);
+    }
+  }
+
+  @Override
+  public void onAfterSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit, SQLException e) {
+    for (JdbcEventListener eventListener : eventListeners) {
+      eventListener.onAfterSetAutoCommit(connectionInformation, newAutoCommit,oldAutoCommit,e);
+    }
+  }
+
 }

--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -39,6 +39,20 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
     this.eventListeners = eventListeners;
   }
 
+
+  /**
+   * adds a listener to this {@link CompoundJdbcEventListener}
+   * @param listener the listener to add
+   * @deprecated this method name has a typo, please use {@link CompoundJdbcEventListener#addListener}
+   */
+  public void addListender(JdbcEventListener listener) {
+    addListener(listener);
+  }
+
+  /**
+   * adds a listener to this {@link CompoundJdbcEventListener}
+   * @param listener the listener to add
+   */
   public void addListener(JdbcEventListener listener) {
     eventListeners.add(listener);
   }

--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -315,9 +315,9 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
   }
 
   @Override
-  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
+  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean currentAutoCommit) {
     for (JdbcEventListener eventListener : eventListeners) {
-      eventListener.onBeforeSetAutoCommit(connectionInformation, newAutoCommit,oldAutoCommit);
+      eventListener.onBeforeSetAutoCommit(connectionInformation, newAutoCommit,currentAutoCommit);
     }
   }
 

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -437,7 +437,7 @@ public abstract class JdbcEventListener {
 
 
   /**
-   * this callbacl method is executed before calling {@link Connection#setAutoCommit(boolean)}
+   * this callback method is executed before calling {@link Connection#setAutoCommit(boolean)}
    * @param connectionInformation The meta information about the {@link Connection} being invoked
    * @param newAutoCommit the new auto commit flag about to be set
    * @param oldAutoCommit the old auto commit flag about to be changed
@@ -448,7 +448,7 @@ public abstract class JdbcEventListener {
 
 
   /**
-   * this callbacl method is executed after {@link Connection#setAutoCommit(boolean)} was called.
+   * this callback method is executed after {@link Connection#setAutoCommit(boolean)} was called.
    * @param connectionInformation The meta information about the {@link Connection} being invoked
    * @param newAutoCommit the new auto commit flag about to be set
    * @param oldAutoCommit the old auto commit flag about to be changed

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -435,4 +435,27 @@ public abstract class JdbcEventListener {
   public void onAfterStatementClose(StatementInformation statementInformation, SQLException e) {
   }
 
+
+  /**
+   * this callbacl method is executed before calling {@link Connection#setAutoCommit(boolean)}
+   * @param connectionInformation The meta information about the {@link Connection} being invoked
+   * @param newAutoCommit the new auto commit flag about to be set
+   * @param oldAutoCommit the old auto commit flag about to be changed
+   */
+  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
+  }
+
+
+
+  /**
+   * this callbacl method is executed after {@link Connection#setAutoCommit(boolean)} was called.
+   * @param connectionInformation The meta information about the {@link Connection} being invoked
+   * @param newAutoCommit the new auto commit flag about to be set
+   * @param oldAutoCommit the old auto commit flag about to be changed
+   * @param e the exception object if {@link Connection#setAutoCommit(boolean)} failed
+   */
+  public void onAfterSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit, SQLException e) {
+  }
+
+
 }

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -437,10 +437,11 @@ public abstract class JdbcEventListener {
 
 
   /**
-   * this callback method is executed before calling {@link Connection#setAutoCommit(boolean)}
+   * This callback method is executed before calling {@link Connection#setAutoCommit(boolean)}
+   *
    * @param connectionInformation The meta information about the {@link Connection} being invoked
-   * @param newAutoCommit the new auto commit flag about to be set
-   * @param oldAutoCommit the old auto commit flag about to be changed
+   * @param newAutoCommit         The new auto commit flag about to be set
+   * @param oldAutoCommit         The old auto commit flag about to be changed
    */
   public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
   }
@@ -448,11 +449,13 @@ public abstract class JdbcEventListener {
 
 
   /**
-   * this callback method is executed after {@link Connection#setAutoCommit(boolean)} was called.
+   * This callback method is executed after {@link Connection#setAutoCommit(boolean)} was called.
+   *
    * @param connectionInformation The meta information about the {@link Connection} being invoked
-   * @param newAutoCommit the new auto commit flag about to be set
-   * @param oldAutoCommit the old auto commit flag about to be changed
-   * @param e the exception object if {@link Connection#setAutoCommit(boolean)} failed
+   * @param newAutoCommit         The new auto commit flag about to be set
+   * @param oldAutoCommit         The old auto commit flag about to be changed
+   * @param e                     The {@link SQLException} which may be triggered by the call (<code>null</code> if
+   *                              there was no exception).
    */
   public void onAfterSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit, SQLException e) {
   }

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -441,9 +441,9 @@ public abstract class JdbcEventListener {
    *
    * @param connectionInformation The meta information about the {@link Connection} being invoked
    * @param newAutoCommit         The new auto commit flag about to be set
-   * @param oldAutoCommit         The old auto commit flag about to be changed
+   * @param currentAutoCommit     The current auto commit flag about to be changed
    */
-  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
+  public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean currentAutoCommit) {
   }
 
 
@@ -452,9 +452,9 @@ public abstract class JdbcEventListener {
    * This callback method is executed after {@link Connection#setAutoCommit(boolean)} was called.
    *
    * @param connectionInformation The meta information about the {@link Connection} being invoked
-   * @param newAutoCommit         The new auto commit flag about to be set
-   * @param oldAutoCommit         The old auto commit flag about to be changed
-   * @param e                     The {@link SQLException} which may be triggered by the call (<code>null</code> if
+   * @param newAutoCommit         The new auto commit flag that was set if no exception was thrown
+   * @param oldAutoCommit         The old auto commit flag
+   * @param e                     The {@link SQLException} which may be triggered by the call, (<code>null</code> if
    *                              there was no exception).
    */
   public void onAfterSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit, SQLException e) {

--- a/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
+++ b/src/main/java/com/p6spy/engine/spy/DefaultJdbcEventListenerFactory.java
@@ -47,7 +47,7 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
       synchronized (DefaultJdbcEventListenerFactory.class) {
         if (jdbcEventListener == null) {
           CompoundJdbcEventListener compoundEventListener = new CompoundJdbcEventListener();
-          compoundEventListener.addListender(DefaultEventListener.INSTANCE);
+          compoundEventListener.addListener(DefaultEventListener.INSTANCE);
           registerEventListenersFromFactories(compoundEventListener);
           registerEventListenersFromServiceLoader(compoundEventListener);
           jdbcEventListener = compoundEventListener;
@@ -68,7 +68,7 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
       for (P6Factory factory : factories) {
         final JdbcEventListener eventListener = factory.getJdbcEventListener();
         if (eventListener != null) {
-          compoundEventListener.addListender(eventListener);
+          compoundEventListener.addListener(eventListener);
         }
       }
     }
@@ -76,7 +76,7 @@ public class DefaultJdbcEventListenerFactory implements JdbcEventListenerFactory
 
   protected void registerEventListenersFromServiceLoader(CompoundJdbcEventListener compoundEventListener) {
     for (Iterator<JdbcEventListener> iterator = jdbcEventListenerServiceLoader.iterator(); iterator.hasNext(); ) {
-      compoundEventListener.addListender(iterator.next());
+      compoundEventListener.addListener(iterator.next());
     }
   }
   

--- a/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
@@ -210,7 +210,17 @@ public class ConnectionWrapper extends AbstractWrapper implements Connection {
 
   @Override
   public void setAutoCommit(boolean autoCommit) throws SQLException {
-    delegate.setAutoCommit(autoCommit);
+    SQLException e = null;
+    boolean oldAutoCommit = delegate.getAutoCommit();
+    try {
+      jdbcEventListener.onBeforeSetAutoCommit(connectionInformation,autoCommit,oldAutoCommit);
+      delegate.setAutoCommit(autoCommit);
+    }catch (SQLException sqle){
+      e = sqle;
+      throw e;
+    }finally {
+      jdbcEventListener.onAfterSetAutoCommit(connectionInformation,autoCommit,oldAutoCommit,e);
+    }
   }
 
   @Override

--- a/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
@@ -213,13 +213,13 @@ public class ConnectionWrapper extends AbstractWrapper implements Connection {
     SQLException e = null;
     boolean oldAutoCommit = delegate.getAutoCommit();
     try {
-      jdbcEventListener.onBeforeSetAutoCommit(connectionInformation,autoCommit,oldAutoCommit);
+      jdbcEventListener.onBeforeSetAutoCommit(connectionInformation, autoCommit, oldAutoCommit);
       delegate.setAutoCommit(autoCommit);
-    }catch (SQLException sqle){
+    } catch (SQLException sqle){
       e = sqle;
       throw e;
-    }finally {
-      jdbcEventListener.onAfterSetAutoCommit(connectionInformation,autoCommit,oldAutoCommit,e);
+    } finally {
+      jdbcEventListener.onAfterSetAutoCommit(connectionInformation, autoCommit, oldAutoCommit, e);
     }
   }
 


### PR DESCRIPTION
This fork adds an event before and after Connection.setAutoCommit.
and fixes a typo in com.p6spy.engine.event.CompoundJdbcEventListener#addListener

the events:
 public void onBeforeSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit) {
  }

  public void onAfterSetAutoCommit(ConnectionInformation connectionInformation, boolean newAutoCommit, boolean oldAutoCommit, SQLException e) {
  }