### PR TITLE
fix: throwing exception when failed to create PrintStream (#478)

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/appender/FileLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/FileLogger.java
@@ -38,7 +38,7 @@ public class FileLogger extends StdoutLogger {
     try {
       printStream = new PrintStream(new FileOutputStream(fileName, P6SpyOptions.getActiveInstance().getAppend()));
     } catch (IOException e) {
-      e.printStackTrace(System.err);
+      throw new IllegalStateException("couldn't create PrintStream for " + fileName, e);
     }
   }
 


### PR DESCRIPTION
Rethrowing exception instead of writing stacktrace to error stream that follows with NPE.