### PR TITLE
Draft of changes to introduce new log placeholder "attributes".

### DIFF
--- a/src/main/java/com/p6spy/engine/common/Loggable.java
+++ b/src/main/java/com/p6spy/engine/common/Loggable.java
@@ -17,6 +17,8 @@
  */
 package com.p6spy.engine.common;
 
+import java.util.Map;
+
 /**
  * Assures capability of the class to be logged by {@link P6LogQuery}.
  *
@@ -38,5 +40,10 @@ public interface Loggable {
    * @return the connection information.
    */
   ConnectionInformation getConnectionInformation();
+
+  /**
+   * @return the additional attributes requested for logging.
+   */
+  Map<String, String> getAttributeValues();
 
 }

--- a/src/main/java/com/p6spy/engine/common/P6Util.java
+++ b/src/main/java/com/p6spy/engine/common/P6Util.java
@@ -226,5 +226,46 @@ public class P6Util {
     return sb.toString();
   }
 
+  /**
+   * Get Enum values matching the list of strings by using case-insensitive search.
+   *
+   * @param enumeration the Enumeration class
+   * @param prefix      the optional prefix to be omitted from the values
+   * @param values      the values to be parsed
+   * @param <T>         the enumeration class
+   * @return            the list of matched enumeration values
+   */
+  public static <T extends Enum<?>> List<T> findEnumMatches(Class<T> enumeration, String prefix, List<String> values) {
+    List<T> newAttributes = null;
+
+    if (values != null && ! values.isEmpty()) {
+      for (String name : values) {
+        if (name.startsWith(prefix)) {
+          name = name.substring(prefix.length());
+        } else if (! "*".equals(name)) {
+          continue;
+        }
+
+        if ("*".equals(name)) {
+          newAttributes = new ArrayList<T>(Arrays.asList(enumeration.getEnumConstants()));
+          break;
+        } else {
+          for (T each : enumeration.getEnumConstants()) {
+            // Use case-insensitive search:
+            if (each.name().equalsIgnoreCase(name)) {
+              if (newAttributes == null) {
+                newAttributes = new ArrayList<T>();
+              }
+              newAttributes.add(each);
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    return newAttributes;
+  }
+
 }
 

--- a/src/main/java/com/p6spy/engine/spy/appender/BatchFileLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/BatchFileLogger.java
@@ -19,6 +19,8 @@ package com.p6spy.engine.spy.appender;
 
 import com.p6spy.engine.logging.Category;
 
+import java.util.Map;
+
 /**
  * SQL batch file logger Private: (?) No Appender that writes a trace of JDBC activity into an SQL
  * batch file that can be later "replayed" using a generic SQL client.
@@ -44,7 +46,7 @@ public class BatchFileLogger extends FileLogger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url, Map<String, String> attributes) {
     if (endOfStatement) {
       getStream().println(BATCH_SEPARATOR);
     }

--- a/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/CustomLineFormat.java
@@ -17,11 +17,16 @@
  */
 package com.p6spy.engine.spy.appender;
 
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.common.ResultSetInformation;
+import com.p6spy.engine.common.StatementInformation;
+import com.p6spy.engine.spy.P6SpyOptions;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import com.p6spy.engine.common.P6Util;
-import com.p6spy.engine.spy.P6SpyOptions;
 
 /**
  * @author Peter G. Horvath
@@ -31,15 +36,56 @@ public class CustomLineFormat implements MessageFormattingStrategy {
 
   private static final MessageFormattingStrategy FALLBACK_FORMATTING_STRATEGY = new SingleLineFormat();
 
-  public static final String CONNECTION_ID = "%(connectionId)";
-  public static final String CURRENT_TIME = "%(currentTime)";
-  public static final String EXECUTION_TIME = "%(executionTime)";
-  public static final String CATEGORY = "%(category)";
-  public static final String EFFECTIVE_SQL = "%(effectiveSql)";
-  public static final String EFFECTIVE_SQL_SINGLELINE = "%(effectiveSqlSingleLine)";
-  public static final String SQL = "%(sql)";
-  public static final String SQL_SINGLE_LINE = "%(sqlSingleLine)";
-  public static final String URL = "%(url)";
+  private static String lastProcessedFormat = null;
+  private static final AtomicBoolean formatParsingInProgress = new AtomicBoolean(false);
+
+  private static boolean isUsed_EFFECTIVE_SQL_SINGLELINE = false;
+  private static boolean isUsed_SQL_SINGLE_LINE = false;
+  private static boolean isUsed_ATTRIBUTES = false;
+
+  private static List<String> usedAttributesPlaceholders = Collections.emptyList();
+
+  private static final String TAG_PREFIX = "%(";
+  private static final String TAG_SUFFIX = ")";
+
+  private static final String TAG_CONNECTION_ID = "connectionId";
+  private static final String TAG_CURRENT_TIME = "currentTime";
+  private static final String TAG_EXECUTION_TIME = "executionTime";
+  private static final String TAG_CATEGORY = "category";
+  private static final String TAG_EFFECTIVE_SQL = "effectiveSql";
+  private static final String TAG_EFFECTIVE_SQL_SINGLELINE = "effectiveSqlSingleLine";
+  private static final String TAG_SQL = "sql";
+  private static final String TAG_SQL_SINGLE_LINE = "sqlSingleLine";
+  private static final String TAG_URL = "url";
+
+  private static final String ATTRIBUTES_PREFIX = "attributes:";
+  private static final String ATTRIBUTES_REGEX   = ATTRIBUTES_PREFIX + "[* .,a-zA-Z]+";
+  private static final Pattern ATTRIBUTES_PATTERN = Pattern.compile(Pattern.quote(TAG_PREFIX) + ATTRIBUTES_REGEX + Pattern.quote(TAG_SUFFIX));
+
+  public static final String CONNECTION_ID            = TAG_PREFIX + TAG_CONNECTION_ID + TAG_SUFFIX;
+  public static final String CURRENT_TIME             = TAG_PREFIX + TAG_CURRENT_TIME + TAG_SUFFIX;
+  public static final String EXECUTION_TIME           = TAG_PREFIX + TAG_EXECUTION_TIME + TAG_SUFFIX;
+  public static final String CATEGORY                 = TAG_PREFIX + TAG_CATEGORY + TAG_SUFFIX;
+  public static final String EFFECTIVE_SQL            = TAG_PREFIX + TAG_EFFECTIVE_SQL + TAG_SUFFIX;
+  public static final String EFFECTIVE_SQL_SINGLELINE = TAG_PREFIX + TAG_EFFECTIVE_SQL_SINGLELINE + TAG_SUFFIX;
+  public static final String SQL                      = TAG_PREFIX + TAG_SQL + TAG_SUFFIX;
+  public static final String SQL_SINGLE_LINE          = TAG_PREFIX + TAG_SQL_SINGLE_LINE + TAG_SUFFIX;
+  public static final String URL                      = TAG_PREFIX + TAG_URL + TAG_SUFFIX;
+
+  private static final Pattern AllPlaceholdersPattern = Pattern.compile(Pattern.quote(TAG_PREFIX) +
+    "(" +
+      TAG_CONNECTION_ID + "|" +
+      TAG_CURRENT_TIME + "|" +
+      TAG_EXECUTION_TIME + "|" +
+      TAG_CATEGORY + "|" +
+      TAG_EFFECTIVE_SQL + "|" +
+      TAG_EFFECTIVE_SQL_SINGLELINE + "|" +
+      TAG_SQL + "|" +
+      TAG_SQL_SINGLE_LINE + "|" +
+      TAG_URL + "|" +
+      ATTRIBUTES_REGEX +
+    ")" +
+    Pattern.quote(TAG_SUFFIX));
 
   /**
    * Formats a log message for the logging module
@@ -51,27 +97,106 @@ public class CustomLineFormat implements MessageFormattingStrategy {
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
    * @param url          the database url where the sql statement executed
+   * @param attributes   the additional attributes requested for logging
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url,
+                              final Map<String, String> attributes) {
 
     String customLogMessageFormat = P6SpyOptions.getActiveInstance().getCustomLogMessageFormat();
 
     if (customLogMessageFormat == null) {
       // Someone forgot to configure customLogMessageFormat: fall back to built-in
-      return FALLBACK_FORMATTING_STRATEGY.formatMessage(connectionId, now, elapsed, category, prepared, sql, url);
+      return FALLBACK_FORMATTING_STRATEGY.formatMessage(connectionId, now, elapsed, category, prepared, sql, url, attributes);
     }
 
-    return customLogMessageFormat
-      .replaceAll(Pattern.quote(CONNECTION_ID), Integer.toString(connectionId))
-      .replaceAll(Pattern.quote(CURRENT_TIME), now)
-      .replaceAll(Pattern.quote(EXECUTION_TIME), Long.toString(elapsed))
-      .replaceAll(Pattern.quote(CATEGORY), category)
-      .replaceAll(Pattern.quote(EFFECTIVE_SQL), Matcher.quoteReplacement(prepared))
-      .replaceAll(Pattern.quote(EFFECTIVE_SQL_SINGLELINE), Matcher.quoteReplacement(P6Util.singleLine(prepared)))
-      .replaceAll(Pattern.quote(SQL), Matcher.quoteReplacement(sql))
-      .replaceAll(Pattern.quote(SQL_SINGLE_LINE), Matcher.quoteReplacement(P6Util.singleLine(sql)))
-      .replaceAll(Pattern.quote(URL), url);
+    // If the log format has changed, make sure that only one thread parses the new style.
+    // We can safely compare pointers to the format String, because it is cached in the active instance until it changes.
+    if (lastProcessedFormat != customLogMessageFormat && formatParsingInProgress.compareAndSet(false, true)) {
+      try {
+        parseNewFormat(customLogMessageFormat);
+      } finally {
+        lastProcessedFormat = customLogMessageFormat;
+        formatParsingInProgress.set(false);
+      }
+    }
+
+    Map<String, String> replacements = new HashMap<String, String>() {{
+      put(CONNECTION_ID, Integer.toString(connectionId));
+      put(CURRENT_TIME, now);
+      put(EXECUTION_TIME, Long.toString(elapsed));
+      put(CATEGORY, category);
+      put(EFFECTIVE_SQL, Matcher.quoteReplacement(prepared));
+      put(SQL, Matcher.quoteReplacement(sql));
+      put(URL, url);
+
+      if (isUsed_EFFECTIVE_SQL_SINGLELINE) {
+        put(EFFECTIVE_SQL_SINGLELINE, Matcher.quoteReplacement(P6Util.singleLine(prepared)));
+      }
+
+      if (isUsed_SQL_SINGLE_LINE) {
+        put(SQL_SINGLE_LINE, Matcher.quoteReplacement(P6Util.singleLine(sql)));
+      }
+
+      if (isUsed_ATTRIBUTES && ! usedAttributesPlaceholders.isEmpty()) {
+        // We're only expanding the first placeholder for the Attributes and the rest will be printed empty
+        put(usedAttributesPlaceholders.get(0), attributes != null ? attributes.toString() : "");
+      }
+    }};
+
+    StringBuffer output = new StringBuffer();
+    try {
+      Matcher m = AllPlaceholdersPattern.matcher(lastProcessedFormat);
+
+      while (m.find()) {
+        String replacement = replacements.get(m.group());
+        m.appendReplacement(output, replacement != null ? replacement : "");
+      }
+      m.appendTail(output);
+    } catch (Exception ex) {
+      // Make sure that any exceptions from the Matcher are not breaking the main application
+System.out.println("=== Got Exception : " + Arrays.toString(ex.getStackTrace()));
+    }
+
+    return output.toString();
+  }
+
+  private static void parseNewFormat(String customLogMessageFormat) {
+    // Turn off any previously used Attribute Placeholders:
+    usedAttributesPlaceholders = Collections.emptyList();
+
+    // Set flags to indicate the presence of Attributes that require additional logic to get their values:
+    isUsed_EFFECTIVE_SQL_SINGLELINE = customLogMessageFormat.contains(EFFECTIVE_SQL_SINGLELINE);
+    isUsed_SQL_SINGLE_LINE          = customLogMessageFormat.contains(SQL_SINGLE_LINE);
+    isUsed_ATTRIBUTES               = customLogMessageFormat.contains(TAG_PREFIX + ATTRIBUTES_PREFIX);
+
+    if (isUsed_ATTRIBUTES) {
+      List<String> customAttributes = new ArrayList<String>();
+      List<String> customAttributePlaceholders = new ArrayList<String>();
+
+      try {
+        Matcher m = ATTRIBUTES_PATTERN.matcher(customLogMessageFormat);
+        while (m.find()) {
+          String requestedAttributes = m.group();
+          customAttributePlaceholders.add(requestedAttributes);
+
+          // Extract the individual attributes from the placeholder:
+          requestedAttributes = requestedAttributes.substring(requestedAttributes.indexOf(":") + 1);
+          requestedAttributes = requestedAttributes.substring(0, requestedAttributes.length() - 1).trim();
+          customAttributes.addAll(Arrays.asList(requestedAttributes.split(" *,+ *")));
+        }
+      } catch (RuntimeException ignored) {
+        // In case the Mather throws any RuntimeExceptions, we must ignore it and not interrupt the main application
+System.out.println("=== Got Exception : " + Arrays.toString(ignored.getStackTrace()));
+      }
+System.out.println("=== parsed customAttributes : " + customAttributes.toString());
+
+      ConnectionInformation.setAttributesToLog(customAttributes);
+      StatementInformation.setAttributesToLog(customAttributes);
+      ResultSetInformation.setAttributesToLog(customAttributes);
+
+      usedAttributesPlaceholders = customAttributePlaceholders;
+    }
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/FormattedLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/FormattedLogger.java
@@ -19,6 +19,8 @@ package com.p6spy.engine.spy.appender;
 
 import com.p6spy.engine.logging.Category;
 
+import java.util.Map;
+
 /**
  * {@link P6Logger} implementation providing support for pluggable {@link MessageFormattingStrategy}.
  */
@@ -31,8 +33,8 @@ public abstract class FormattedLogger implements P6Logger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
-    logText(strategy.formatMessage(connectionId, now, elapsed, category.toString(), prepared, sql, url));
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url, Map<String, String> attributes) {
+    logText(strategy.formatMessage(connectionId, now, elapsed, category.toString(), prepared, sql, url, attributes));
   }
 
   /**

--- a/src/main/java/com/p6spy/engine/spy/appender/MessageFormattingStrategy.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/MessageFormattingStrategy.java
@@ -17,6 +17,8 @@
  */
 package com.p6spy.engine.spy.appender;
 
+import java.util.Map;
+
 /**
  * @author Quinton McCombs
  * @since 09/2013
@@ -32,8 +34,9 @@ public interface MessageFormattingStrategy {
    * @param prepared the SQL statement with all bind variables replaced with actual values
    * @param sql the sql statement executed
    * @param url the database url where the sql statement executed
+   * @param attributes the additional attributes requested for logging
    * @return the formatted log message
    */
-  String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url);
+  String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url, Map<String, String> attributes);
 
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/MultiLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/MultiLineFormat.java
@@ -17,6 +17,8 @@
  */
 package com.p6spy.engine.spy.appender;
 
+import java.util.Map;
+
 /**
  * @author Quinton McCombs 
  * @since 09/2013
@@ -33,10 +35,11 @@ public class MultiLineFormat implements MessageFormattingStrategy {
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
    * @param url          the database url where the sql statement executed
+   * @param attributes   the additional attributes requested for logging
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url, Map<String, String> attributes) {
     return "#" + now + " | took " + elapsed + "ms | " + category + " | connection " + connectionId + "| url " + url + "\n" + prepared + "\n" + sql +";";
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/P6Logger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/P6Logger.java
@@ -19,6 +19,8 @@ package com.p6spy.engine.spy.appender;
 
 import com.p6spy.engine.logging.Category;
 
+import java.util.Map;
+
 public interface P6Logger {
 
         /**
@@ -29,6 +31,7 @@ public interface P6Logger {
          * @param now
          *            current time.
          * @param elapsed
+         *            the time in milliseconds that the operation took to complete
          * @param category
          *            the category to be used for logging.
          * @param prepared
@@ -37,9 +40,12 @@ public interface P6Logger {
          *            the {@code SQL} to be logged.
          * @param url
          *            the database url where the sql statement executed
+         * @param attributes
+         *            the additional attributes requested for logging
          */
         public void logSQL(int connectionId, String now, long elapsed,
-                        Category category, String prepared, String sql, String url);
+                           Category category, String prepared, String sql, String url,
+                           Map<String, String> attributes);
 
         /**
          * Logs the stacktrace of the exception.

--- a/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/SingleLineFormat.java
@@ -19,6 +19,8 @@ package com.p6spy.engine.spy.appender;
 
 import com.p6spy.engine.common.P6Util;
 
+import java.util.Map;
+
 /**
  * @author Quinton McCombs
  * @since 09/2013
@@ -35,10 +37,11 @@ public class SingleLineFormat implements MessageFormattingStrategy {
    * @param prepared     the SQL statement with all bind variables replaced with actual values
    * @param sql          the sql statement executed
    * @param url          the database url where the sql statement executed
+   * @param attributes   the additional attributes requested for logging
    * @return the formatted log message
    */
   @Override
-  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url) {
-    return now + "|" + elapsed + "|" + category + "|connection " + connectionId + "|url " + url + "|" + P6Util.singleLine(prepared) + "|" + P6Util.singleLine(sql);
+  public String formatMessage(final int connectionId, final String now, final long elapsed, final String category, final String prepared, final String sql, final String url, Map<String, String> attributes) {
+    return new StringBuilder().append(now).append("|").append(elapsed).append("|").append(category).append("|connection ").append(connectionId).append("|url ").append(url).append("|").append(P6Util.singleLine(prepared)).append("|").append(P6Util.singleLine(sql)).toString();
   }
 }

--- a/src/main/java/com/p6spy/engine/spy/appender/Slf4JLogger.java
+++ b/src/main/java/com/p6spy/engine/spy/appender/Slf4JLogger.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import com.p6spy.engine.logging.Category;
 
+import java.util.Map;
+
 /**
  * Appender which delegates to SLF4J. All log messages are logged at the INFO
  * level using the "p6spy" category, except debug and error ones that log on the
@@ -46,9 +48,10 @@ public class Slf4JLogger extends FormattedLogger {
 
 	@Override
 	public void logSQL(int connectionId, String now, long elapsed,
-			Category category, String prepared, String sql, String url) {
+                     Category category, String prepared, String sql, String url,
+                     Map<String, String> attributes) {
 		final String msg = strategy.formatMessage(connectionId, now, elapsed,
-				category.toString(), prepared, sql, url);
+				category.toString(), prepared, sql, url, null);
 
 		if (Category.ERROR.equals(category)) {
 			log.error(msg);

--- a/src/main/java/com/p6spy/engine/wrapper/ResultSetWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ResultSetWrapper.java
@@ -68,6 +68,8 @@ public class ResultSetWrapper extends AbstractWrapper implements ResultSet {
     this.delegate = delegate;
     this.resultSetInformation = resultSetInformation;
     this.eventListener = eventListener;
+
+    this.resultSetInformation.captureAttributeValues(delegate);
   }
 
   @Override
@@ -734,6 +736,7 @@ public class ResultSetWrapper extends AbstractWrapper implements ResultSet {
 
   @Override
   public void setFetchSize(int rows) throws SQLException {
+    resultSetInformation.setFetchSize(rows);
     delegate.setFetchSize(rows);
   }
 

--- a/src/main/java/com/p6spy/engine/wrapper/StatementWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/StatementWrapper.java
@@ -55,6 +55,8 @@ public class StatementWrapper extends AbstractWrapper implements Statement {
     this.delegate = delegate;
     this.eventListener = eventListener;
     this.statementInformation = statementInformation;
+
+    this.statementInformation.captureAttributeValues(delegate);
   }
 
   @Override
@@ -306,6 +308,7 @@ public class StatementWrapper extends AbstractWrapper implements Statement {
 
   @Override
   public void setQueryTimeout(int seconds) throws SQLException {
+    statementInformation.setQueryTimeout(seconds);
     delegate.setQueryTimeout(seconds);
   }
 
@@ -351,6 +354,7 @@ public class StatementWrapper extends AbstractWrapper implements Statement {
 
   @Override
   public void setFetchSize(int rows) throws SQLException {
+    statementInformation.setFetchSize(rows);
     delegate.setFetchSize(rows);
   }
 

--- a/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
@@ -38,7 +38,7 @@ public class CustomLineFormatTest {
 		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(customLogMessageFormat);
 		String logMsg = new CustomLineFormat().formatMessage(0, "1", 1L, "statement",
 				"select value from V$parameter where lower(name)=?",
-				"select value from V$parameter where lower(name)='compatible'", "jdbc:h2:mem:p6spyDSTest");
+				"select value from V$parameter where lower(name)='compatible'", "jdbc:h2:mem:p6spyDSTest", null);
 
 		Assert.assertTrue(logMsg.contains(
 				"select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));

--- a/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/P6TestLogger.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.p6spy.engine.logging.Category;
 
@@ -48,8 +49,8 @@ public class P6TestLogger extends StdoutLogger {
   }
 
   @Override
-  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url) {
-    super.logSQL(connectionId, now, elapsed, category, prepared, sql, url);
+  public void logSQL(int connectionId, String now, long elapsed, Category category, String prepared, String sql, String url, Map<String, String> attributes) {
+    super.logSQL(connectionId, now, elapsed, category, prepared, sql, url, attributes);
     times.add(elapsed);
   }
 


### PR DESCRIPTION
The placeholder for the CustomLineFormat will allow additional attributes to be logged for the Connection, Statement and ResultSet objects.  The list of attributes to include in the log will be specified in the suffix of the placeholder like this:
    %(attributes:*) - log all captured attributes of the current Category
    %(attributes:Statement.*) - log all attributes only for "statement" Category
    %(attributes:Connection.getSchema,Statement.isAutoCommitted,ResultSet.*) - log the specified attributes only

 This is a draft:
 - the list of attributes for each Category is not final and can be extended at any point
 - the tests have not been created yet