### PR TITLE
fix NPE for binary/varbinary/blob when P6LogFactory not registered

### DIFF
--- a/src/main/java/com/p6spy/engine/common/Value.java
+++ b/src/main/java/com/p6spy/engine/common/Value.java
@@ -17,6 +17,7 @@
  */
 package com.p6spy.engine.common;
 
+import com.p6spy.engine.logging.P6LogLoadableOptions;
 import com.p6spy.engine.logging.P6LogOptions;
 import com.p6spy.engine.spy.P6SpyOptions;
 
@@ -95,7 +96,9 @@ public class Value {
           result = value.toString();
         }
       } else if (value instanceof byte[]) {
-        if (P6LogOptions.getActiveInstance().getExcludebinary()) {
+        // P6LogFactory may not be registered
+    	P6LogLoadableOptions logOptions = P6LogOptions.getActiveInstance();
+        if (logOptions != null && logOptions.getExcludebinary()) {
           result = "[binary]";
         } else {
           result = toHexString((byte[]) value);

--- a/src/main/java/com/p6spy/engine/common/Value.java
+++ b/src/main/java/com/p6spy/engine/common/Value.java
@@ -97,7 +97,7 @@ public class Value {
         }
       } else if (value instanceof byte[]) {
         // P6LogFactory may not be registered
-    	P6LogLoadableOptions logOptions = P6LogOptions.getActiveInstance();
+        P6LogLoadableOptions logOptions = P6LogOptions.getActiveInstance();
         if (logOptions != null && logOptions.getExcludebinary()) {
           result = "[binary]";
         } else {
@@ -107,7 +107,8 @@ public class Value {
         // we should not do ((Blob) value).getBinaryStream(). ...
         // as inputstream might not be re-rea
 //      } else  if (value instanceof Blob) {
-//        if (P6LogOptions.getActiveInstance().getExcludebinary()) {
+//        P6LogLoadableOptions logOptions = P6LogOptions.getActiveInstance();
+//        if (logOptions != null && logOptions.getExcludebinary()) {
 //          result = "[binary]";
 //        } else {
 //          result = value.toString();

--- a/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
+++ b/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
@@ -151,8 +151,8 @@ public class P6ModuleManager {
 		  
 	  final P6LoadableOptions options = factory.getOptions(optionsRepository);
       loadOptions(options);
-      
-      allOptions.put(options.getClass(), options);
+
+      // allOptions.put(options.getClass(), options); // Called in loadOptions(options);
       factories.add(factory);
       
       debug("Registered factory: " + factory.getClass().getName() + " with options: " + options.getClass().getName());

--- a/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
+++ b/src/main/java/com/p6spy/engine/spy/P6ModuleManager.java
@@ -152,7 +152,6 @@ public class P6ModuleManager {
 	  final P6LoadableOptions options = factory.getOptions(optionsRepository);
       loadOptions(options);
 
-      // allOptions.put(options.getClass(), options); // Called in loadOptions(options);
       factories.add(factory);
       
       debug("Registered factory: " + factory.getClass().getName() + " with options: " + options.getClass().getName());


### PR DESCRIPTION
I found a NPE when a binary/varbinary/blob type in SQL, because I disable registering P6LogFactory (to avoid massive log):

    java.lang.NullPointerException
        at com.p6spy.engine.common.Value.convertToString(Value.java:98)
        at com.p6spy.engine.common.Value.toString(Value.java:63)
        at com.p6spy.engine.common.PreparedStatementInformation.getSqlWithValues(PreparedStatementInformation.java:56)
        ...

So I add the null check for `P6LogOptions.getActiveInstance()`.

btw, duplicated `allOptions.put(...)` call in `P6ModuleManager` removed.