### PR TITLE
add ConnectionInformation.getTimeToCloseConnectionNs()

### DIFF
--- a/src/main/java/com/p6spy/engine/common/ConnectionInformation.java
+++ b/src/main/java/com/p6spy/engine/common/ConnectionInformation.java
@@ -37,6 +37,7 @@ public class ConnectionInformation implements Loggable {
   private Connection connection;
   private PooledConnection pooledConnection;
   private long timeToGetConnectionNs;
+  private long timeToCloseConnectionNs;
   private String url;
 
   private ConnectionInformation() {
@@ -213,6 +214,19 @@ public class ConnectionInformation implements Loggable {
 
   public void setTimeToGetConnectionNs(long timeToGetConnectionNs) {
     this.timeToGetConnectionNs = timeToGetConnectionNs;
+  }
+
+  /**
+   * Returns the time it took to close the connection in nanoseconds
+   *
+   * @return the time it took to close the connection in nanoseconds
+   */
+  public long getTimeToCloseConnectionNs() {
+    return timeToCloseConnectionNs;
+  }
+
+  public void setTimeToCloseConnectionNs(long timeToCloseConnectionNs) {
+    this.timeToCloseConnectionNs = timeToCloseConnectionNs;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/ConnectionWrapper.java
@@ -231,12 +231,14 @@ public class ConnectionWrapper extends AbstractWrapper implements Connection {
   @Override
   public void close() throws SQLException {
     SQLException e = null;
+    long start = System.nanoTime();
     try {
       delegate.close();
     } catch (SQLException sqle) {
       e = sqle;
       throw e;
     } finally {
+      connectionInformation.setTimeToCloseConnectionNs(System.nanoTime() - start);
       jdbcEventListener.onAfterConnectionClose(connectionInformation, e);
     }
   }


### PR DESCRIPTION
Similar to `ConnectionInformation.getTimeToCloseConnectionNs()` this can let us know how long a connection closes, e.g.

```
public class P6Factory extends P6SpyFactory {
    @Override
    public JdbcEventListener getJdbcEventListener() {
        return new SimpleJdbcEventListener() {
            @Override
            public void onAfterGetConnection(ConnectionInformation ci, SQLException e) {
                // log connect elapse via ci.getTimeToGetConnectionNs()
            }

            @Override
            public void onAfterConnectionClose(ConnectionInformation ci, SQLException e) {
                // log disconnect elapse via ci.getTimeToCloseConnectionNs()
            }

            ...
        }
    }
}
```

The process to close a connection may include:

* rollback transactions
* close statements
* close session
* TCP disconnect
* ...

This may cost long time in some tricky scenarios, which should be logged and monitored.