### PR TITLE
The file.encoding configuration encoding is used by default to read the configuration file, and the encoding is specified through -Dspy.properties.charset = utf-8

### DIFF
--- a/src/main/java/com/p6spy/engine/spy/option/SpyDotProperties.java
+++ b/src/main/java/com/p6spy/engine/spy/option/SpyDotProperties.java
@@ -22,6 +22,7 @@ import com.p6spy.engine.spy.P6ModuleManager;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Map;
@@ -30,36 +31,38 @@ import java.util.Properties;
 public class SpyDotProperties implements P6OptionsSource {
 
   public static final String OPTIONS_FILE_PROPERTY = "spy.properties";
+  public static final String OPTIONS_FILE_CHARSET_PROPERTY = OPTIONS_FILE_PROPERTY.concat(".charset");
   public static final String DEFAULT_OPTIONS_FILE = OPTIONS_FILE_PROPERTY;
 
   private final long lastModified;
-  
+
   private SpyDotPropertiesReloader reloader;
 
   private final Map<String, String> options;
 
   /**
    * Creates a new instance and loads the properties file if found.
-   * 
+   *
    * @throws IOException
    */
   public SpyDotProperties() throws IOException {
     URL url = locate();
-    
+
     if (null == url) {
       // no config file preset => skip props loading
       lastModified = -1;
       options = null;
       return;
     }
-    
+
     lastModified = lastModified();
 
     InputStream in = null;
     try {
       in = url.openStream();
       final Properties properties = new Properties();
-      properties.load(in);
+      String charsetName = System.getProperty(OPTIONS_FILE_CHARSET_PROPERTY,"GBK");
+      properties.load(new InputStreamReader(in ,charsetName));
       options = P6Util.getPropertiesMap(properties);
     } finally {
       if (null != in) {
@@ -74,20 +77,20 @@ public class SpyDotProperties implements P6OptionsSource {
 
   /**
    * Determines if the file has been modified since it was loaded
-   * 
+   *
    * @return true if modified, false otherwise
    */
   public boolean isModified() {
     return lastModified() != lastModified;
   }
-  
+
   private long lastModified() {
     long lastMod = -1;
     URLConnection con = null;
     URL url = locate();
     if( url != null ) {
       try {
-        con = url.openConnection(); 
+        con = url.openConnection();
         lastMod = con.getLastModified();
       } catch (IOException e) {
         // ignore

--- a/src/main/java/com/p6spy/engine/spy/option/SpyDotProperties.java
+++ b/src/main/java/com/p6spy/engine/spy/option/SpyDotProperties.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Properties;
 
@@ -61,8 +62,9 @@ public class SpyDotProperties implements P6OptionsSource {
     try {
       in = url.openStream();
       final Properties properties = new Properties();
-      String charsetName = System.getProperty(OPTIONS_FILE_CHARSET_PROPERTY,"GBK");
-      properties.load(new InputStreamReader(in ,charsetName));
+
+      String charsetName = System.getProperty(OPTIONS_FILE_CHARSET_PROPERTY, Charset.defaultCharset().name());
+      properties.load(new InputStreamReader(in, charsetName));
       options = P6Util.getPropertiesMap(properties);
     } finally {
       if (null != in) {


### PR DESCRIPTION
Adjusted the configuration of the default encoding