### PR TITLE
Binary data representation can be customized according to database dialect

### DIFF
--- a/docs/configandusage.md
+++ b/docs/configandusage.md
@@ -162,6 +162,12 @@ in section: [Configuration and Usage](#configuration-and-usage)):
     # format that is used for logging booleans, possible values: boolean, numeric
     # (default is boolean)
     #databaseDialectBooleanFormat=boolean
+    
+    # Specifies the format for logging binary data. Not applicable if excludebinary is true.
+    # (default is com.p6spy.engine.logging.format.HexEncodedBinaryFormat)
+    #databaseDialectBinaryFormat=com.p6spy.engine.logging.format.PostgreSQLBinaryFormat
+    #databaseDialectBinaryFormat=com.p6spy.engine.logging.format.MySQLBinaryFormat
+    #databaseDialectBinaryFormat=com.p6spy.engine.logging.format.HexEncodedBinaryFormat
 
     # whether to expose options via JMX or not
     # (default is true)

--- a/src/main/assembly/individualFiles/spy.properties
+++ b/src/main/assembly/individualFiles/spy.properties
@@ -124,6 +124,12 @@
 # (default is boolean)
 # databaseDialectBooleanFormat=boolean
 
+# Specifies the format for logging binary data. Not applicable if excludebinary is true.
+# (default is com.p6spy.engine.logging.format.HexEncodedBinaryFormat)
+#databaseDialectBinaryFormat=com.p6spy.engine.logging.format.PostgreSQLBinaryFormat
+#databaseDialectBinaryFormat=com.p6spy.engine.logging.format.MySQLBinaryFormat
+#databaseDialectBinaryFormat=com.p6spy.engine.logging.format.HexEncodedBinaryFormat
+
 # whether to expose options via JMX or not
 # (default is true)
 #jmx=true

--- a/src/main/java/com/p6spy/engine/logging/format/BinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/BinaryFormat.java
@@ -1,0 +1,35 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2020 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.logging.format;
+
+public interface BinaryFormat {
+  /**
+   * Transforms the supplied binary data to a string representation.
+   * 
+   * @param input
+   *    the binary data input value to convert to {@link String}
+   * @return
+   *    the {@link String} representation of the given bytes
+   */
+  public String toString(byte[] input);
+
+  /**
+   * Tells whether this binary format needs quotes around the string value when used in queries.
+   */
+  public boolean needsQuotes();
+}

--- a/src/main/java/com/p6spy/engine/logging/format/BinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/BinaryFormat.java
@@ -20,6 +20,7 @@ package com.p6spy.engine.logging.format;
 public interface BinaryFormat {
   /**
    * Transforms the supplied binary data to a string representation.
+   * Wraps the value in quotes if the database dialect requires them.
    * 
    * @param input
    *    the binary data input value to convert to {@link String}
@@ -27,9 +28,4 @@ public interface BinaryFormat {
    *    the {@link String} representation of the given bytes
    */
   public String toString(byte[] input);
-
-  /**
-   * Tells whether this binary format needs quotes around the string value when used in queries.
-   */
-  public boolean needsQuotes();
 }

--- a/src/main/java/com/p6spy/engine/logging/format/HexEncodedBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/HexEncodedBinaryFormat.java
@@ -24,20 +24,24 @@ public class HexEncodedBinaryFormat implements BinaryFormat {
   private static final char[] HEX_CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
       'F' };
 
+  /**
+   * The space needed for the opening and closing quote character.
+   */
+  private static final int QUOTE_COUNT = 2;
+
   @Override
   public String toString(byte[] input) {
-    char[] result = new char[input.length * 2];
-    hexEncode(input, result, 0);
+    char[] result = new char[QUOTE_COUNT + input.length * 2];
+    int i = 0;
+    result[i++] = '\''; // add opening quote
+    hexEncode(input, result, i);
+    result[result.length - 1] = '\''; // add closing quote
     return new String(result);
   }
 
-  @Override
-  public boolean needsQuotes() {
-    return true;
-  }
-  
   /**
    * Hex encodes the supplied input bytes to the supplied output array.
+   * Writes two {@code char}s of output for every {@code byte} of input.
    * @param input the input array
    * @param output the output array
    * @param outputOffset the offset of the output array to start writing from

--- a/src/main/java/com/p6spy/engine/logging/format/HexEncodedBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/HexEncodedBinaryFormat.java
@@ -1,0 +1,53 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2020 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.logging.format;
+
+/**
+ * Transforms binary data to hex encoded strings.
+ */
+public class HexEncodedBinaryFormat implements BinaryFormat {
+  private static final char[] HEX_CHARS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E',
+      'F' };
+
+  @Override
+  public String toString(byte[] input) {
+    char[] result = new char[input.length * 2];
+    hexEncode(input, result, 0);
+    return new String(result);
+  }
+
+  @Override
+  public boolean needsQuotes() {
+    return true;
+  }
+  
+  /**
+   * Hex encodes the supplied input bytes to the supplied output array.
+   * @param input the input array
+   * @param output the output array
+   * @param outputOffset the offset of the output array to start writing from
+   */
+  static void hexEncode(byte[] input, char[] output, int outputOffset) {
+    int idx = outputOffset;
+    for (byte b : input) {
+      int temp = (int) b & 0xFF;
+      output[idx++] = HEX_CHARS[temp / 16];
+      output[idx++] = HEX_CHARS[temp % 16];
+    }
+  }
+}

--- a/src/main/java/com/p6spy/engine/logging/format/MySQLBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/MySQLBinaryFormat.java
@@ -1,0 +1,46 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2020 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.logging.format;
+
+/**
+ * Transforms binary data to MySQL hex encoded strings, for example {@code 0x8088BAD639F}.
+ * Such strings are not quoted when used in queries.
+ * 
+ * @see <a href="https://dev.mysql.com/doc/refman/5.6/en/hexadecimal-literals.html">MySQL documentation</a>
+ */
+public class MySQLBinaryFormat implements BinaryFormat {
+
+  /**
+   * Reserve space for the two prefix chars 0 and x
+   */
+  private static final int PREFIX_LENGTH = 2;
+  
+  @Override
+  public String toString(byte[] input) {
+    char[] result = new char[PREFIX_LENGTH + input.length * 2];
+    result[0] = '0';
+    result[1] = 'x';
+    HexEncodedBinaryFormat.hexEncode(input, result, PREFIX_LENGTH);
+    return new String(result);
+  }
+
+  @Override
+  public boolean needsQuotes() {
+    return false;
+  }
+}

--- a/src/main/java/com/p6spy/engine/logging/format/MySQLBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/MySQLBinaryFormat.java
@@ -29,18 +29,15 @@ public class MySQLBinaryFormat implements BinaryFormat {
    * Reserve space for the two prefix chars 0 and x
    */
   private static final int PREFIX_LENGTH = 2;
-  
-  @Override
-  public String toString(byte[] input) {
-    char[] result = new char[PREFIX_LENGTH + input.length * 2];
-    result[0] = '0';
-    result[1] = 'x';
-    HexEncodedBinaryFormat.hexEncode(input, result, PREFIX_LENGTH);
-    return new String(result);
-  }
 
   @Override
-  public boolean needsQuotes() {
-    return false;
+  public String toString(byte[] input) {
+    
+    char[] result = new char[PREFIX_LENGTH + input.length * 2];
+    int i = 0;
+    result[i++] = '0';
+    result[i++] = 'x';
+    HexEncodedBinaryFormat.hexEncode(input, result, i);
+    return new String(result);
   }
 }

--- a/src/main/java/com/p6spy/engine/logging/format/PostgreSQLBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/PostgreSQLBinaryFormat.java
@@ -28,18 +28,21 @@ public class PostgreSQLBinaryFormat implements BinaryFormat {
    * Reserve space for the two prefix chars \ and x
    */
   private static final int PREFIX_LENGTH = 2;
-  
-  @Override
-  public String toString(byte[] input) {
-    char[] result = new char[PREFIX_LENGTH + input.length * 2];
-    result[0] = '\\';
-    result[1] = 'x';
-    HexEncodedBinaryFormat.hexEncode(input, result, PREFIX_LENGTH);
-    return new String(result);
-  }
+
+  /**
+   * The space needed for the opening and closing quote character.
+   */
+  private static final int QUOTE_COUNT = 2;
 
   @Override
-  public boolean needsQuotes() {
-    return true;
+  public String toString(byte[] input) {
+    char[] result = new char[PREFIX_LENGTH + QUOTE_COUNT + input.length * 2];
+    int i = 0;
+    result[i++] = '\''; // opening quote
+    result[i++] = '\\'; // PostgreSQL binary...
+    result[i++] = 'x'; //  ...data prefix
+    HexEncodedBinaryFormat.hexEncode(input, result, i);
+    result[result.length - 1] = '\''; // closing quote
+    return new String(result);
   }
 }

--- a/src/main/java/com/p6spy/engine/logging/format/PostgreSQLBinaryFormat.java
+++ b/src/main/java/com/p6spy/engine/logging/format/PostgreSQLBinaryFormat.java
@@ -1,0 +1,45 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 - 2020 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.logging.format;
+
+/**
+ * Transforms binary data to PostgreSQL hex encoded strings, for example {@code \x8088BAD639F}
+ * 
+ * @see <a href="https://www.postgresql.org/docs/current/datatype-binary.html#id-1.5.7.12.9">PostgreSQL documentation</a>
+ */
+public class PostgreSQLBinaryFormat implements BinaryFormat {
+
+  /**
+   * Reserve space for the two prefix chars \ and x
+   */
+  private static final int PREFIX_LENGTH = 2;
+  
+  @Override
+  public String toString(byte[] input) {
+    char[] result = new char[PREFIX_LENGTH + input.length * 2];
+    result[0] = '\\';
+    result[1] = 'x';
+    HexEncodedBinaryFormat.hexEncode(input, result, PREFIX_LENGTH);
+    return new String(result);
+  }
+
+  @Override
+  public boolean needsQuotes() {
+    return true;
+  }
+}

--- a/src/main/java/com/p6spy/engine/spy/P6SpyLoadableOptions.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyLoadableOptions.java
@@ -19,6 +19,7 @@ package com.p6spy.engine.spy;
 
 import java.util.Set;
 
+import com.p6spy.engine.logging.format.BinaryFormat;
 import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
 import com.p6spy.engine.spy.appender.P6Logger;
 
@@ -37,6 +38,12 @@ public interface P6SpyLoadableOptions extends P6LoadableOptions, P6SpyOptionsMBe
   void setAppend(String append);
   
   P6Logger getAppenderInstance();
+  
+  /**
+   * Gets an instance of the database dialect {@link BinaryFormat} the implementing class of which is
+   * set by {@link P6SpyOptionsMBean#setDatabaseDialectBinaryFormat}.
+   */
+  BinaryFormat getDatabaseDialectBinaryFormatInstance();
 
   MessageFormattingStrategy getLogMessageFormatInstance();
   

--- a/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyOptions.java
@@ -25,6 +25,8 @@ import javax.management.StandardMBean;
 
 import com.p6spy.engine.common.P6Util;
 import com.p6spy.engine.logging.P6LogFactory;
+import com.p6spy.engine.logging.format.BinaryFormat;
+import com.p6spy.engine.logging.format.HexEncodedBinaryFormat;
 import com.p6spy.engine.spy.appender.*;
 import com.p6spy.engine.spy.option.P6OptionsRepository;
 
@@ -52,6 +54,8 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
     public static final String DATABASE_DIALECT_DATE_FORMAT = "databaseDialectDateFormat";
     public static final String DATABASE_DIALECT_TIMESTAMP_FORMAT = "databaseDialectTimestampFormat";
     public static final String DATABASE_DIALECT_BOOLEAN_FORMAT = "databaseDialectBooleanFormat";
+    public static final String DATABASE_DIALECT_BINARY_FORMAT = "databaseDialectBinaryFormat";
+    public static final String DATABASE_DIALECT_BINARY_FORMAT_INSTANCE = "databaseDialectBinaryFormatInstance";
     public static final String JMX = "jmx";
     public static final String JMX_PREFIX = "jmxPrefix";
 
@@ -78,6 +82,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       defaults.put(DATABASE_DIALECT_DATE_FORMAT, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
       defaults.put(DATABASE_DIALECT_TIMESTAMP_FORMAT, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
       defaults.put(DATABASE_DIALECT_BOOLEAN_FORMAT, "boolean");
+      defaults.put(DATABASE_DIALECT_BINARY_FORMAT, HexEncodedBinaryFormat.class.getName());
       defaults.put(CUSTOM_LOG_MESSAGE_FORMAT, String.format("%s|%s|%s|connection%s|%s",
         CustomLineFormat.CURRENT_TIME, CustomLineFormat.EXECUTION_TIME, CustomLineFormat.CATEGORY,
         CustomLineFormat.CONNECTION_ID, CustomLineFormat.SQL_SINGLE_LINE));
@@ -114,6 +119,7 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
       setDatabaseDialectDateFormat(options.get(DATABASE_DIALECT_DATE_FORMAT));
       setDatabaseDialectTimestampFormat(options.get(DATABASE_DIALECT_TIMESTAMP_FORMAT));
       setDatabaseDialectBooleanFormat(options.get(DATABASE_DIALECT_BOOLEAN_FORMAT));
+      setDatabaseDialectBinaryFormat(options.get(DATABASE_DIALECT_BINARY_FORMAT));
       setCustomLogMessageFormat(options.get(CUSTOM_LOG_MESSAGE_FORMAT));
       setJmx(options.get(JMX));
       setJmxPrefix(options.get(JMX_PREFIX));
@@ -349,6 +355,37 @@ public class P6SpyOptions extends StandardMBean implements P6SpyLoadableOptions 
   public void setDatabaseDialectBooleanFormat(String databaseDialectBooleanFormat) {
     optionsRepository.set(String.class, DATABASE_DIALECT_BOOLEAN_FORMAT, databaseDialectBooleanFormat);
   }
+  
+    /**
+     * Returns the class name of the database dialect binary format.
+     *
+     * @return String
+     */
+    @Override
+    public String getDatabaseDialectBinaryFormat() {
+      return optionsRepository.get(String.class, DATABASE_DIALECT_BINARY_FORMAT);
+    }
+
+    /**
+     * Sets the class name of the database dialect binary format.
+     *
+     * @param className The class name to set
+     */
+    @Override
+    public void setDatabaseDialectBinaryFormat(String className) {
+      optionsRepository.set(String.class, DATABASE_DIALECT_BINARY_FORMAT, className);
+      optionsRepository.set(BinaryFormat.class, DATABASE_DIALECT_BINARY_FORMAT_INSTANCE, className);
+    }
+
+    /**
+     * Returns the class name of the database dialect binary format.
+     *
+     * @return String
+     */
+    @Override
+    public BinaryFormat getDatabaseDialectBinaryFormatInstance() {
+      return optionsRepository.get(BinaryFormat.class, DATABASE_DIALECT_BINARY_FORMAT_INSTANCE);
+    }
 
     /**
      * Returns the customLogMessageFormat.

--- a/src/main/java/com/p6spy/engine/spy/P6SpyOptionsMBean.java
+++ b/src/main/java/com/p6spy/engine/spy/P6SpyOptionsMBean.java
@@ -97,7 +97,17 @@ public interface P6SpyOptionsMBean {
   String getDatabaseDialectBooleanFormat();
 
   void setDatabaseDialectBooleanFormat(String databaseDialectBooleanFormat);
+  
+  /**
+   * Gets the class name of the database dialect binary formatter.
+   */
+  String getDatabaseDialectBinaryFormat();
 
+  /**
+   * Sets the class name of the database dialect binary formatter.
+   */
+  void setDatabaseDialectBinaryFormat(String className);
+  
   String getCustomLogMessageFormat();
 
   void setCustomLogMessageFormat(String customLogMessageFormat);


### PR DESCRIPTION
As discussed in #501.

I was not able to run the whole test suite because of issues with Gradle. I ran the new and existing test cases in `P6TestResultSetWithBinary` individually and they pass.