### PR TITLE
Directly set daemon flag for outage thread

### DIFF
--- a/src/main/java/com/p6spy/engine/outage/P6OutageDetector.java
+++ b/src/main/java/com/p6spy/engine/outage/P6OutageDetector.java
@@ -64,6 +64,7 @@ public enum P6OutageDetector implements Runnable {
     	ThreadGroup group = new ThreadGroup("P6SpyThreadGroup");
         group.setDaemon(true);
         Thread outageThread = new Thread(group, this, "P6SpyOutageThread");
+        outageThread.setDaemon(true);      
         outageThread.start();
     	
         P6LogQuery.debug("P6Spy - P6OutageDetector has been invoked.");


### PR DESCRIPTION
It appears that the thread members of a thread group don't inherit daemon flag from the group itself

Fixes issue #523