### PR TITLE
Use the timezone from the Calendar that may be passed as 3rd arg in setTimestamp setTime and setDate 

### DIFF
--- a/src/main/java/com/p6spy/engine/common/PreparedStatementInformation.java
+++ b/src/main/java/com/p6spy/engine/common/PreparedStatementInformation.java
@@ -17,6 +17,7 @@
  */
 package com.p6spy.engine.common;
 
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -70,6 +71,16 @@ public class PreparedStatementInformation extends StatementInformation implement
    */
   public void setParameterValue(final int position, final Object value) {
     parameterValues.put(position - 1, new Value(value));
+  }
+
+  /**
+   * Records the value of a parameter.
+   * @param position the position of the parameter (starts with 1 not 0)
+   * @param value the value of the parameter
+   * @param timezoneHolder the Calendar holding the timezone information for temporal values (Dates and Timestamps)
+   */
+  public void setParameterValue(final int position, final Object value, final Calendar timezoneHolder) {
+    parameterValues.put(position - 1, new Value(value, timezoneHolder));
   }
 
   protected Map<Integer, Value> getParameterValues() {

--- a/src/main/java/com/p6spy/engine/common/Value.java
+++ b/src/main/java/com/p6spy/engine/common/Value.java
@@ -24,6 +24,7 @@ import com.p6spy.engine.spy.P6SpyOptions;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.regex.Pattern;
 
@@ -43,9 +44,20 @@ public class Value {
    */
   private Object value;
 
+  /**
+   * Calendar used to store the timezone for Date, Time And Timestamp types
+   */
+  private Calendar timezoneHolder = null;
+
   public Value(Object valueToSet) {
     this();
     this.value = valueToSet;
+  }
+
+  public Value(Object valueToSet, Calendar timezoneHolder) {
+    this();
+    this.value = valueToSet;
+    this.timezoneHolder = timezoneHolder;
   }
 
   public Value() {
@@ -108,9 +120,17 @@ public class Value {
 //          result = value.toString();
 //        }
       } else if (value instanceof Timestamp) {
-        result = new SimpleDateFormat(P6SpyOptions.getActiveInstance().getDatabaseDialectTimestampFormat()).format(value);
+        SimpleDateFormat sdf = new SimpleDateFormat(P6SpyOptions.getActiveInstance().getDatabaseDialectTimestampFormat());
+        if (timezoneHolder != null) {
+          sdf.setTimeZone(timezoneHolder.getTimeZone());
+        }
+        result = sdf.format(value);
       } else if (value instanceof Date) {
-        result = new SimpleDateFormat(P6SpyOptions.getActiveInstance().getDatabaseDialectDateFormat()).format(value);
+        SimpleDateFormat sdf = new SimpleDateFormat(P6SpyOptions.getActiveInstance().getDatabaseDialectDateFormat());
+        if (timezoneHolder != null) {
+          sdf.setTimeZone(timezoneHolder.getTimeZone());
+        }
+        result = sdf.format(value);
       } else if (value instanceof Boolean) {
         if ("numeric".equals(P6SpyOptions.getActiveInstance().getDatabaseDialectBooleanFormat())) {
           result = Boolean.FALSE.equals(value) ? "0" : "1";

--- a/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/CompoundJdbcEventListener.java
@@ -25,6 +25,7 @@ import com.p6spy.engine.common.StatementInformation;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
@@ -220,6 +221,13 @@ public class CompoundJdbcEventListener extends JdbcEventListener {
   public void onAfterPreparedStatementSet(PreparedStatementInformation statementInformation, int parameterIndex, Object value, SQLException e) {
     for (JdbcEventListener eventListener : eventListeners) {
       eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, value, e);
+    }
+  }
+
+  @Override
+  public void onAfterPreparedStatementSet(PreparedStatementInformation statementInformation, int parameterIndex, Object value, Calendar timezoneHolder, SQLException e) {
+    for (JdbcEventListener eventListener : eventListeners) {
+      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, value, timezoneHolder, e);
     }
   }
 

--- a/src/main/java/com/p6spy/engine/event/DefaultEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/DefaultEventListener.java
@@ -23,6 +23,7 @@ import com.p6spy.engine.common.ResultSetInformation;
 import com.p6spy.engine.common.StatementInformation;
 
 import java.sql.SQLException;
+import java.util.Calendar;
 
 /**
  * This implementation of {@link JdbcEventListener} must always be applied as the first listener.
@@ -98,4 +99,8 @@ public class DefaultEventListener extends JdbcEventListener {
     statementInformation.setParameterValue(parameterIndex, value);
   }
 
+  @Override
+  public void onAfterPreparedStatementSet(PreparedStatementInformation statementInformation, int parameterIndex, Object value, Calendar timezoneHolder, SQLException e) {
+    statementInformation.setParameterValue(parameterIndex, value, timezoneHolder);
+  }
 }

--- a/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
+++ b/src/main/java/com/p6spy/engine/event/JdbcEventListener.java
@@ -33,6 +33,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.sql.Statement;
+import java.util.Calendar;
 
 /**
  * Implementations of this class receive notifications for interesting JDBC events.
@@ -295,6 +296,20 @@ public abstract class JdbcEventListener {
    *                             there was no exception).
    */
   public void onAfterPreparedStatementSet(PreparedStatementInformation statementInformation, int parameterIndex, Object value, SQLException e) {
+  }
+
+
+  /**
+   * This callback method is executed after any of the {@link PreparedStatement}.set* methods are invoked.
+   *
+   * @param statementInformation The meta information about the {@link Statement} being invoked
+   * @param parameterIndex       The first parameter is 1, the second is 2, ...
+   * @param value                the column value; if the value is SQL NULL, the value returned is null
+   * @param timezoneHolder       the Calendar holding the timezone information for temporal values (Dates and Timestamps)
+   * @param e                    The {@link SQLException} which may be triggered by the call (<code>null</code> if
+   *                             there was no exception).
+   */
+  public void onAfterPreparedStatementSet(PreparedStatementInformation statementInformation, int parameterIndex, Object value, Calendar timezoneHolder, SQLException e) {
   }
 
   /**

--- a/src/main/java/com/p6spy/engine/wrapper/PreparedStatementWrapper.java
+++ b/src/main/java/com/p6spy/engine/wrapper/PreparedStatementWrapper.java
@@ -457,7 +457,7 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
       e = sqle;
       throw e;
     } finally {
-      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, e);
+      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, cal, e);
     }
   }
 
@@ -470,7 +470,7 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
       e = sqle;
       throw e;
     } finally {
-      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, e);
+      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, cal, e);
     }
   }
 
@@ -483,7 +483,7 @@ public class PreparedStatementWrapper extends StatementWrapper implements Prepar
       e = sqle;
       throw e;
     } finally {
-      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, e);
+      eventListener.onAfterPreparedStatementSet(statementInformation, parameterIndex, x, cal, e);
     }
   }
 

--- a/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
+++ b/src/test/java/com/p6spy/engine/event/CompoundJdbcEventListenerTest.java
@@ -471,7 +471,7 @@ public class CompoundJdbcEventListenerTest {
     final Date date = mock(Date.class);
     final Calendar calendar = mock(Calendar.class);
     wrappedPreparedStatement.setDate(0, date, calendar);
-    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(date),
+    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(date), eq(calendar),
         ArgumentMatchers.<SQLException>isNull());
   }
 
@@ -488,7 +488,7 @@ public class CompoundJdbcEventListenerTest {
     final Time time = mock(Time.class);
     final Calendar calendar = mock(Calendar.class);
     wrappedPreparedStatement.setTime(0, time, calendar);
-    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(time),
+    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(time), eq(calendar),
         ArgumentMatchers.<SQLException>isNull());
   }
 
@@ -505,7 +505,7 @@ public class CompoundJdbcEventListenerTest {
     final Timestamp timestamp = new Timestamp(System.currentTimeMillis());
     final Calendar calendar = mock(Calendar.class);
     wrappedPreparedStatement.setTimestamp(0, timestamp, calendar);
-    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(timestamp),
+    verify(mockedJdbcListener).onAfterPreparedStatementSet(eq(preparedStatementInformation), eq(0), eq(timestamp), eq(calendar),
         ArgumentMatchers.<SQLException>isNull());
   }
 


### PR DESCRIPTION
Use the timezone from the Calendar that may be passed to PreparedStatement#setTimestamp, PreparedStatement#setTime and PreparedStatement#setDate to format the date

According to the doc : With a Calendar object, the driver can calculate the date taking into account a custom timezone. If no Calendar object is specified, the driver uses the default timezone, which is that of the virtual machine running the application
Therefore the SimpleDateFormat used to print the sql query should use this information instead of the default timezone