### PR TITLE
JUnit 5 migration (#507)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,14 @@ dependencies {
   compileOnly 'ch.qos.logback:logback-classic:1.2.3'
   compileOnly 'ch.qos.logback:logback-core:1.2.3'
 
-  testCompile 'junit:junit:4.12'
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
+
+  // junit4 support
+  testImplementation("junit:junit:4.13")
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.7.1")
+
   testCompile 'org.eclipse.jetty:jetty-plus:9.4.12.v20180830' // datasource testing through JNDI
   testCompile 'commons-dbcp:commons-dbcp:1.4' // datasource testing
   testCompile 'org.codehaus.btm:btm:2.1.4' // xa datasource testing
@@ -92,6 +99,7 @@ dependencies {
   testCompile 'org.apache.commons:commons-lang3:3.8.1'
   testCompile 'commons-beanutils:commons-beanutils:1.9.3'
   testCompile 'org.mockito:mockito-core:2.22.0'
+  testCompile 'org.mockito:mockito-junit-jupiter:2.23.0'
   testCompile 'org.apache.tomcat:tomcat-jdbc:9.0.12' // tomcat pooled datasource testing
 
   // all the JDBC drivers tested
@@ -128,6 +136,9 @@ license {
 }
 
 test {
+
+    useJUnitPlatform()
+
     systemProperty 'user.language', 'en'
     systemProperty 'user.country', 'US'
     systemProperty 'derby.stream.error.file', 'target/derby.log'

--- a/src/test/java/com/p6spy/engine/common/CustomHashedHashSetTest.java
+++ b/src/test/java/com/p6spy/engine/common/CustomHashedHashSetTest.java
@@ -17,14 +17,18 @@
  */
 package com.p6spy.engine.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.logging.P6LogFactory;
 import com.p6spy.engine.spy.P6Factory;
@@ -40,7 +44,7 @@ public class CustomHashedHashSetTest {
 	private P6SpyFactory fs1 = new P6SpyFactory();
 	private P6SpyFactory fs2 = new P6SpyFactory();
 	
-	@Before
+	@BeforeEach
 	public void before() {
 		hasher = new ClassHasher();
 		set = new CustomHashedHashSet<P6Factory>(hasher);
@@ -48,49 +52,49 @@ public class CustomHashedHashSetTest {
 		fl1 = new P6LogFactory();
 		fl2 = new P6LogFactory();
 		
-		Assert.assertNotEquals(fl1.hashCode(), fl2.hashCode());
-		Assert.assertEquals(hasher.getHashCode(fl1), hasher.getHashCode(fl2));
+		assertNotEquals(fl1.hashCode(), fl2.hashCode());
+		assertEquals(hasher.getHashCode(fl1), hasher.getHashCode(fl2));
 		
 		fs1 = new P6SpyFactory();
 		fs2 = new P6SpyFactory();
 		
-		Assert.assertNotEquals(fs1.hashCode(), fs2.hashCode());
-		Assert.assertEquals(hasher.getHashCode(fs1), hasher.getHashCode(fs2));
+		assertNotEquals(fs1.hashCode(), fs2.hashCode());
+		assertEquals(hasher.getHashCode(fs1), hasher.getHashCode(fs2));
 
-		Assert.assertEquals(0, set.size());
+		assertEquals(0, set.size());
 	}
 	
 	@Test
 	public void testAdd() {
 		set.add(fl1);
-		Assert.assertEquals(1, set.size());
+		assertEquals(1, set.size());
 		set.add(fl2);
-		Assert.assertEquals(1, set.size());
+		assertEquals(1, set.size());
 		
 		set.addAll(Arrays.asList(fs1, fs2));
-		Assert.assertEquals(2, set.size());
+		assertEquals(2, set.size());
 	}
 	
 	@Test
 	public void testRemove() {
 		set.addAll(Arrays.asList(fl1, fl2, fs1, fs2));
-		Assert.assertEquals(2, set.size());
+		assertEquals(2, set.size());
 		
 		set.remove(fl1);
-		Assert.assertEquals(1, set.size());
+		assertEquals(1, set.size());
 		set.removeAll(Arrays.asList(fs1, fs2));
-		Assert.assertEquals(0, set.size());
+		assertEquals(0, set.size());
 	}
 	
 	@Test
 	public void testContains() {
-		Assert.assertFalse(set.contains(fl1));
+		assertFalse(set.contains(fl1));
 		
 		set.addAll(Arrays.asList(fl1, fs1));
-		Assert.assertTrue(set.contains(fl1));
-		Assert.assertTrue(set.contains(fl2));
-		Assert.assertTrue(set.contains(fs1));
-		Assert.assertTrue(set.contains(fs2));
+		assertTrue(set.contains(fl1));
+		assertTrue(set.contains(fl2));
+		assertTrue(set.contains(fs1));
+		assertTrue(set.contains(fs2));
 	}
 	
 	@Test
@@ -101,8 +105,8 @@ public class CustomHashedHashSetTest {
 		
 		for (Iterator<P6Factory> it = set.iterator(); it.hasNext();) {
 			Object elem = it.next();
-			Assert.assertTrue(list.contains(elem));
-			Assert.assertFalse(classHashEqualList.contains(elem));
+			assertTrue(list.contains(elem));
+			assertFalse(classHashEqualList.contains(elem));
 		}
 	}
 }

--- a/src/test/java/com/p6spy/engine/common/P6UtilTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6UtilTest.java
@@ -17,6 +17,11 @@
  */
 package com.p6spy.engine.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -24,27 +29,26 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P6UtilTest {
   @Test
   public void testSingleLine() {
-      Assert.assertEquals("abc efg", P6Util.singleLine("abc\nefg"));
-      Assert.assertEquals("abc efg", P6Util.singleLine("abc\n\nefg"));
-      Assert.assertEquals("abc efg", P6Util.singleLine("abc\r\n\nefg"));
+      assertEquals("abc efg", P6Util.singleLine("abc\nefg"));
+      assertEquals("abc efg", P6Util.singleLine("abc\n\nefg"));
+      assertEquals("abc efg", P6Util.singleLine("abc\r\n\nefg"));
   }
   @Test 
   public void testJoinNullSafe() {
-    Assert.assertEquals("", P6Util.joinNullSafe(null, null));
-    Assert.assertEquals("", P6Util.joinNullSafe(null, ""));
-    Assert.assertEquals("", P6Util.joinNullSafe(null, ","));
-    Assert.assertEquals("", P6Util.joinNullSafe(Collections.<String>emptyList(), null));
-    Assert.assertEquals("", P6Util.joinNullSafe(Collections.<String>emptyList(), ","));
-    Assert.assertEquals("foo", P6Util.joinNullSafe(Arrays.asList("foo"), ","));
-    Assert.assertEquals("foobar", P6Util.joinNullSafe(Arrays.asList("foo", "bar"), null));
-    Assert.assertEquals("foo,bar", P6Util.joinNullSafe(Arrays.asList("foo", "bar"), ","));
-    Assert.assertEquals("foo|bar|aaa", P6Util.joinNullSafe(Arrays.asList("foo", "bar", "aaa"), "|"));
+    assertEquals("", P6Util.joinNullSafe(null, null));
+    assertEquals("", P6Util.joinNullSafe(null, ""));
+    assertEquals("", P6Util.joinNullSafe(null, ","));
+    assertEquals("", P6Util.joinNullSafe(Collections.<String>emptyList(), null));
+    assertEquals("", P6Util.joinNullSafe(Collections.<String>emptyList(), ","));
+    assertEquals("foo", P6Util.joinNullSafe(Arrays.asList("foo"), ","));
+    assertEquals("foobar", P6Util.joinNullSafe(Arrays.asList("foo", "bar"), null));
+    assertEquals("foo,bar", P6Util.joinNullSafe(Arrays.asList("foo", "bar"), ","));
+    assertEquals("foo|bar|aaa", P6Util.joinNullSafe(Arrays.asList("foo", "bar", "aaa"), "|"));
   }
   
   @Test 
@@ -54,11 +58,11 @@ public class P6UtilTest {
 	  properties.load(new ByteArrayInputStream(string.getBytes()));
 	  final Map<String, String> map = P6Util.getPropertiesMap(properties);
 	  
-	  Assert.assertTrue(map.containsKey("key1"));
-	  Assert.assertEquals("", map.get("key1"));
-	  Assert.assertTrue(map.containsKey("key2"));
-	  Assert.assertEquals("val2", map.get("key2"));
-	  Assert.assertFalse(map.containsKey("key3"));
-	  Assert.assertNull(map.get("key3"));
+	  assertTrue(map.containsKey("key1"));
+	  assertEquals("", map.get("key1"));
+	  assertTrue(map.containsKey("key2"));
+	  assertEquals("val2", map.get("key2"));
+	  assertFalse(map.containsKey("key3"));
+	  assertNull(map.get("key3"));
   }
 }

--- a/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperIsWrapperDelegateTest.java
@@ -17,6 +17,9 @@
  */
 package com.p6spy.engine.common;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.p6spy.engine.test.AbstractTestConnection;
 import com.p6spy.engine.test.BaseTestCase;
 import com.p6spy.engine.test.TestConnection;
@@ -24,15 +27,13 @@ import com.p6spy.engine.test.TestConnectionImpl;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 
 import org.apache.commons.dbcp.DelegatingConnection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Wrapper;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class P6WrapperIsWrapperDelegateTest extends BaseTestCase {
 

--- a/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
+++ b/src/test/java/com/p6spy/engine/common/P6WrapperUnwrapDelegateTest.java
@@ -17,9 +17,9 @@
  */
 package com.p6spy.engine.common;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -33,7 +33,7 @@ import com.p6spy.engine.test.TestConnectionImpl;
 import com.p6spy.engine.wrapper.AbstractWrapper;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
 import org.apache.commons.dbcp.DelegatingConnection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class P6WrapperUnwrapDelegateTest extends BaseTestCase {
 

--- a/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/event/EventListenerServiceLoaderTest.java
@@ -17,12 +17,14 @@
  */
 package com.p6spy.engine.event;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.sql.Connection;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.logging.LoggingEventListener;
@@ -30,7 +32,6 @@ import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
 import com.p6spy.engine.test.TestJdbcEventListener;
 import com.p6spy.engine.test.TestLoggingEventListener;
 import com.p6spy.engine.wrapper.ConnectionWrapper;
-import org.junit.Test;
 
 public class EventListenerServiceLoaderTest {
 

--- a/src/test/java/com/p6spy/engine/spy/DataSourceTest.java
+++ b/src/test/java/com/p6spy/engine/spy/DataSourceTest.java
@@ -17,22 +17,10 @@
  */
 package com.p6spy.engine.spy;
 
-import com.p6spy.engine.common.P6LogQuery;
-import com.p6spy.engine.common.P6Util;
-import com.p6spy.engine.spy.appender.P6TestLogger;
-import com.p6spy.engine.test.BaseTestCase;
-import com.p6spy.engine.test.P6TestFramework;
-import com.p6spy.engine.wrapper.AbstractWrapper;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.dbcp.ConnectionFactory;
-import org.apache.commons.dbcp.DriverConnectionFactory;
-import org.eclipse.jetty.plus.jndi.Resource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -41,7 +29,23 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.logging.Logger;
 
-import static org.junit.Assert.*;
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp.ConnectionFactory;
+import org.apache.commons.dbcp.DriverConnectionFactory;
+import org.eclipse.jetty.plus.jndi.Resource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
+
+import com.p6spy.engine.common.P6LogQuery;
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.spy.appender.P6TestLogger;
+import com.p6spy.engine.test.BaseTestCase;
+import com.p6spy.engine.test.P6TestFramework;
+import com.p6spy.engine.wrapper.AbstractWrapper;
 
 /**
  * @author Quinton McCombs
@@ -65,7 +69,7 @@ public class DataSourceTest extends BaseTestCase {
   private String driverClass;
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // make sure to reinit properly
     new P6TestFramework("ds") {
@@ -90,7 +94,7 @@ public class DataSourceTest extends BaseTestCase {
 
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws SQLException {
     try {
       con.close();
@@ -128,19 +132,19 @@ public class DataSourceTest extends BaseTestCase {
 
     // get the data source from JNDI
     DataSource ds = new JndiDataSourceLookup().getDataSource("jdbc/spyDs");
-    assertNotNull("JNDI data source not found", ds);
+    assertNotNull(ds,"JNDI data source not found");
 
     // get the connection
     con = ds.getConnection();
 
     // verify that the connection class is a proxy
-    assertTrue("Connection is not a proxy", AbstractWrapper.isProxy(con));
+    assertTrue(AbstractWrapper.isProxy(con),"Connection is not a proxy");
 
     Statement stmt = con.createStatement();
     stmt.execute("select 1 from customers");
     stmt.close();
     assertTrue(((P6TestLogger) P6LogQuery.getLogger()).getLastEntry().indexOf("select 1") != -1);
-    assertEquals("Incorrect number of spy log messages", 1, ((P6TestLogger) P6LogQuery.getLogger()).getLogs().size());
+    assertEquals(1, ((P6TestLogger) P6LogQuery.getLogger()).getLogs().size(),"Incorrect number of spy log messages");
   }
 
   @Test
@@ -159,13 +163,13 @@ public class DataSourceTest extends BaseTestCase {
 
     // get the data source from JNDI
     DataSource ds = new JndiDataSourceLookup().getDataSource("jdbc/spyDs");
-    assertNotNull("JNDI data source not found", ds);
+    assertNotNull(ds,"JNDI data source not found");
 
     // get the connection
     con = ds.getConnection();
 
     // verify that the connection class is a proxy
-    assertTrue("Connection is not a proxy", AbstractWrapper.isProxy(con));
+    assertTrue( AbstractWrapper.isProxy(con),"Connection is not a proxy");
 
   }
 

--- a/src/test/java/com/p6spy/engine/spy/JdbcEventListenerFactoryLoaderTest.java
+++ b/src/test/java/com/p6spy/engine/spy/JdbcEventListenerFactoryLoaderTest.java
@@ -18,10 +18,11 @@
 package com.p6spy.engine.spy;
 
 import com.p6spy.engine.event.JdbcEventListener;
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 
 public class JdbcEventListenerFactoryLoaderTest {

--- a/src/test/java/com/p6spy/engine/spy/MultipleDataSourceTest.java
+++ b/src/test/java/com/p6spy/engine/spy/MultipleDataSourceTest.java
@@ -17,9 +17,9 @@
  */
 package com.p6spy.engine.spy;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -28,18 +28,19 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.eclipse.jetty.plus.jndi.Resource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
+
 import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.spy.appender.P6TestLogger;
 import com.p6spy.engine.test.BaseTestCase;
 import com.p6spy.engine.test.P6TestFramework;
 import com.p6spy.engine.wrapper.AbstractWrapper;
-import org.eclipse.jetty.plus.jndi.Resource;
-import org.h2.jdbcx.JdbcDataSource;
-import org.hsqldb.jdbc.JDBCDataSource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 
 /**
  * @author Quinton McCombs
@@ -48,7 +49,7 @@ import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 public class MultipleDataSourceTest extends BaseTestCase {
   private List<Resource> jndiResources;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // make sure to reinit properly
     new P6TestFramework("ds") {
@@ -88,7 +89,7 @@ public class MultipleDataSourceTest extends BaseTestCase {
     ((P6TestLogger) P6LogQuery.getLogger()).clearLogs();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     for (Resource resource : jndiResources) {
       try {
@@ -126,13 +127,13 @@ public class MultipleDataSourceTest extends BaseTestCase {
   }
 
   private void validateSpyEnabled(DataSource ds) throws SQLException {
-    assertNotNull("JNDI data source not found", ds);
+    assertNotNull(ds,"JNDI data source not found");
 
     // get the connection
     Connection con = ds.getConnection();
 
     // verify that the connection class is a proxy
-    assertTrue("Connection is not a proxy", AbstractWrapper.isProxy(con.getClass()));
+    assertTrue(AbstractWrapper.isProxy(con.getClass()),"Connection is not a proxy");
 
     if (con.getMetaData().getDatabaseProductName().contains("HSQL")) {
       con.createStatement().execute("set database sql syntax ora true");
@@ -142,7 +143,7 @@ public class MultipleDataSourceTest extends BaseTestCase {
   }
 
   private void validateNotSpyEnabled(DataSource ds) throws SQLException {
-    assertNotNull("JNDI data source not found", ds);
+    assertNotNull(ds,"JNDI data source not found");
 
     // get the connection
     Connection con = ds.getConnection();

--- a/src/test/java/com/p6spy/engine/spy/P6MBeanRegistryTest.java
+++ b/src/test/java/com/p6spy/engine/spy/P6MBeanRegistryTest.java
@@ -17,6 +17,9 @@
  */
 package com.p6spy.engine.spy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -25,9 +28,8 @@ import java.util.Arrays;
 import javax.management.InstanceNotFoundException;
 import javax.management.JMException;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.j256.simplejmx.client.JmxClient;
 import com.p6spy.engine.common.P6Util;
@@ -42,7 +44,7 @@ public class P6MBeanRegistryTest {
 
   private static JmxClient jmxClient = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void connectToJMX() throws JMException, SQLException, IOException,
       InterruptedException {
     final String jmxPortProperty = System
@@ -124,7 +126,7 @@ public class P6MBeanRegistryTest {
     final Boolean append = (Boolean) jmxClient.getAttribute(
         P6MBeansRegistry.getPackageName(jmxPrefix), P6SpyOptions.class.getName(),
         JMX_PROPERTY_APPEND);
-    Assert.assertEquals(append, appendProperty);
+    assertEquals(append, appendProperty);
   }
 
   private void destroyMBean(P6MBeansRegistry mBeansRegistry, final String jmxPrefix)
@@ -149,6 +151,6 @@ public class P6MBeanRegistryTest {
       // we should end up here
       return;
     }
-    Assert.fail();
+    fail();
   }
 }

--- a/src/test/java/com/p6spy/engine/spy/P6TestMBean.java
+++ b/src/test/java/com/p6spy/engine/spy/P6TestMBean.java
@@ -17,8 +17,8 @@
  */
 package com.p6spy.engine.spy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -27,8 +27,8 @@ import java.util.Set;
 import javax.management.JMException;
 import javax.management.ObjectName;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.j256.simplejmx.client.JmxClient;
 import com.p6spy.engine.common.P6Util;
@@ -44,7 +44,7 @@ public class P6TestMBean extends BaseTestCase {
 
   private static JmxClient jmxClient = null;
       
-  @BeforeClass
+  @BeforeAll
   public static void connectToJMX() throws JMException, SQLException, IOException, InterruptedException {
     // make sure to reinit properly
     new P6TestFramework("mbean") {};

--- a/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/CustomLineFormatTest.java
@@ -17,16 +17,16 @@
  */
 package com.p6spy.engine.spy.appender;
 
-import org.junit.After;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.spy.P6SpyOptions;
 
-import org.junit.Assert;
-
 public class CustomLineFormatTest {
 
-	@After
+	@AfterEach
 	public void after() {
 		// reset formatting setting
 		P6SpyOptions.getActiveInstance().setCustomLogMessageFormat(null);
@@ -40,7 +40,7 @@ public class CustomLineFormatTest {
 				"select value from V$parameter where lower(name)=?",
 				"select value from V$parameter where lower(name)='compatible'", "jdbc:h2:mem:p6spyDSTest");
 
-		Assert.assertTrue(logMsg.contains(
+		assertTrue(logMsg.contains(
 				"select value from V$parameter where lower(name)=?\nselect value from V$parameter where lower(name)='compatible';\n"));
 	}
 

--- a/src/test/java/com/p6spy/engine/spy/appender/Log4jLoggerTest.java
+++ b/src/test/java/com/p6spy/engine/spy/appender/Log4jLoggerTest.java
@@ -17,7 +17,7 @@
  */
 package com.p6spy.engine.spy.appender;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -30,9 +30,9 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.xml.DOMConfigurator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.logging.Category;
@@ -48,7 +48,7 @@ public class Log4jLoggerTest extends BaseTestCase {
   
   private P6TestFramework framework;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // reset log4j
     LogManager.resetConfiguration();
@@ -73,7 +73,7 @@ public class Log4jLoggerTest extends BaseTestCase {
     configureLog4JInTest(log4jConfSuffix);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
 	// restore default excluded categories
 	P6LogOptions.getActiveInstance().setExcludecategories(

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionAPI.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionAPI.java
@@ -17,12 +17,15 @@
  */
 package com.p6spy.engine.spy.option;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 import java.sql.SQLException;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.logging.P6LogLoadableOptions;
 import com.p6spy.engine.logging.P6LogOptions;
@@ -33,7 +36,7 @@ import com.p6spy.engine.test.P6TestFramework;
 
 public class P6TestOptionAPI extends BaseTestCase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpAll() throws SQLException, IOException {
     // make sure to reinit properly
     new P6TestFramework("blank") {
@@ -45,34 +48,34 @@ public class P6TestOptionAPI extends BaseTestCase {
     final P6SpyLoadableOptions opts = P6SpyOptions.getActiveInstance();
     
     opts.setJNDIContextCustom("foo");
-    Assert.assertEquals("foo", opts.getJNDIContextCustom());
+    assertEquals("foo", opts.getJNDIContextCustom());
     opts.unSetJNDIContextCustom();
-    Assert.assertNull(opts.getJNDIContextCustom());
+    assertNull(opts.getJNDIContextCustom());
     
     opts.setJNDIContextFactory("fooFactory");
-    Assert.assertEquals("fooFactory", opts.getJNDIContextFactory());
+    assertEquals("fooFactory", opts.getJNDIContextFactory());
     opts.unSetJNDIContextFactory();
-    Assert.assertNull(opts.getJNDIContextFactory());
+    assertNull(opts.getJNDIContextFactory());
     
     opts.setJNDIContextProviderURL("http://fooUrl");
-    Assert.assertEquals("http://fooUrl", opts.getJNDIContextProviderURL());
+    assertEquals("http://fooUrl", opts.getJNDIContextProviderURL());
     opts.unSetJNDIContextProviderURL();
-    Assert.assertNull(opts.getJNDIContextProviderURL());
+    assertNull(opts.getJNDIContextProviderURL());
     
     opts.setRealDataSource("fooDS");
-    Assert.assertEquals("fooDS", opts.getRealDataSource());
+    assertEquals("fooDS", opts.getRealDataSource());
     opts.unSetRealDataSource();
-    Assert.assertNull(opts.getRealDataSource());
+    assertNull(opts.getRealDataSource());
     
     opts.setRealDataSourceClass("fooDSClass");
-    Assert.assertEquals("fooDSClass", opts.getRealDataSourceClass());
+    assertEquals("fooDSClass", opts.getRealDataSourceClass());
     opts.unSetRealDataSourceClass();
-    Assert.assertNull(opts.getRealDataSourceClass());
+    assertNull(opts.getRealDataSourceClass());
     
     opts.setRealDataSourceProperties("fooDSProps");
-    Assert.assertEquals("fooDSProps", opts.getRealDataSourceProperties());
+    assertEquals("fooDSProps", opts.getRealDataSourceProperties());
     opts.unSetRealDataSourceProperties();
-    Assert.assertNull(opts.getRealDataSourceProperties());
+    assertNull(opts.getRealDataSourceProperties());
   }
   
   @Test
@@ -80,11 +83,11 @@ public class P6TestOptionAPI extends BaseTestCase {
     final P6LogLoadableOptions opts = P6LogOptions.getActiveInstance();
     
     opts.setSQLExpression("foo");
-    Assert.assertEquals("foo", opts.getSQLExpression());
-    Assert.assertNotNull(opts.getSQLExpressionPattern());
+    assertEquals("foo", opts.getSQLExpression());
+    assertNotNull(opts.getSQLExpressionPattern());
     opts.unSetSQLExpression();
-    Assert.assertNull(opts.getSQLExpression());
-    Assert.assertNull(opts.getSQLExpressionPattern());
+    assertNull(opts.getSQLExpression());
+    assertNull(opts.getSQLExpressionPattern());
   }
   
 }

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionDefaults.java
@@ -17,6 +17,13 @@
  */
 package com.p6spy.engine.spy.option;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -25,6 +32,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.common.P6LogQuery;
 import com.p6spy.engine.logging.Category;
@@ -44,13 +58,6 @@ import com.p6spy.engine.spy.appender.FileLogger;
 import com.p6spy.engine.spy.appender.SingleLineFormat;
 import com.p6spy.engine.test.BaseTestCase;
 import com.p6spy.engine.test.P6TestFramework;
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class P6TestOptionDefaults extends BaseTestCase {
 
@@ -63,7 +70,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
   private static final List<Class<? extends P6Factory>> DEFAULT_FACTORIES = Arrays.asList(
       P6SpyFactory.class, P6LogFactory.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpAll() throws SQLException, IOException {
     // cleanup all
     LOG_FILE.delete();
@@ -73,7 +80,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
     };
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // make sure to have no modules explicitly loaded by default
     {
@@ -82,12 +89,12 @@ public class P6TestOptionDefaults extends BaseTestCase {
     }
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws SQLException, IOException {
     System.getProperties().remove(SystemProperties.P6SPY_PREFIX + P6SpyOptions.MODULELIST);
   }
   
-  @AfterClass
+  @AfterAll
   public static void tearDownAll() {
     // post clean up
     LOG_FILE.delete();
@@ -97,9 +104,9 @@ public class P6TestOptionDefaults extends BaseTestCase {
   public void testDefaultOptions() {
     assertP6FactoryClassesEqual(DEFAULT_FACTORIES, P6ModuleManager.getInstance().getFactories());
     
-    Assert.assertNotNull(P6SpyOptions.getActiveInstance());
-    Assert.assertNotNull(P6LogOptions.getActiveInstance());
-    Assert.assertNull(P6OutageOptions.getActiveInstance());
+    assertNotNull(P6SpyOptions.getActiveInstance());
+    assertNotNull(P6LogOptions.getActiveInstance());
+    assertNull(P6OutageOptions.getActiveInstance());
   }
   
   private void assertP6FactoryClassesEqual(List<Class<? extends P6Factory>> expected,
@@ -110,46 +117,46 @@ public class P6TestOptionDefaults extends BaseTestCase {
     for (P6Factory factory : factories) {
       expectedSet.remove(factory.getClass());
     }
-    Assert.assertTrue(expectedSet.isEmpty());
+    assertTrue(expectedSet.isEmpty());
   }
   
   @Test
   public void testP6SpyOptionDefaults() {
     P6SpyLoadableOptions opts = P6SpyOptions.getActiveInstance();
-    Assert.assertNotNull(opts);
+    assertNotNull(opts);
 
-    Assert.assertEquals(SingleLineFormat.class.getName(), opts.getLogMessageFormat());
-    Assert.assertEquals("spy.log", opts.getLogfile());
-    Assert.assertTrue(opts.getAppend());
-    Assert.assertNull(opts.getDateformat());
-    Assert.assertEquals(FileLogger.class.getName(), opts.getAppender());
-    Assert.assertEquals(P6SpyFactory.class.getName() + ","+ P6LogFactory.class.getName(), opts.getModulelist());
-    Assert.assertEquals(2, opts.getModuleFactories().size());
+    assertEquals(SingleLineFormat.class.getName(), opts.getLogMessageFormat());
+    assertEquals("spy.log", opts.getLogfile());
+    assertTrue(opts.getAppend());
+    assertNull(opts.getDateformat());
+    assertEquals(FileLogger.class.getName(), opts.getAppender());
+    assertEquals(P6SpyFactory.class.getName() + ","+ P6LogFactory.class.getName(), opts.getModulelist());
+    assertEquals(2, opts.getModuleFactories().size());
     assertP6FactoryClassesEqual(DEFAULT_FACTORIES, opts.getModuleFactories());
-    Assert.assertEquals(2, opts.getModuleNames().size());
-    Assert.assertTrue(opts.getModuleNames().contains(P6SpyFactory.class.getName()));
-    Assert.assertTrue(opts.getModuleNames().contains(P6LogFactory.class.getName()));
-    Assert.assertEquals("", opts.getDriverlist());
-    Assert.assertNull(opts.getDriverNames());
-    Assert.assertFalse(opts.getStackTrace());
-    Assert.assertNull(opts.getStackTraceClass());
-    Assert.assertFalse(opts.getAutoflush());
-    Assert.assertFalse(opts.getReloadProperties());
-    Assert.assertEquals(60L, opts.getReloadPropertiesInterval());
-    Assert.assertNull(opts.getJNDIContextFactory());
-    Assert.assertNull(opts.getJNDIContextProviderURL());
-    Assert.assertNull(opts.getJNDIContextCustom());
-    Assert.assertNull(opts.getRealDataSource());
-    Assert.assertNull(opts.getRealDataSourceClass());
-    Assert.assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSZ", opts.getDatabaseDialectDateFormat());
-    Assert.assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSZ", opts.getDatabaseDialectTimestampFormat());
-    Assert.assertEquals("boolean", opts.getDatabaseDialectBooleanFormat());
-    Assert.assertEquals(String.format("%s|%s|%s|connection%s|%s",
+    assertEquals(2, opts.getModuleNames().size());
+    assertTrue(opts.getModuleNames().contains(P6SpyFactory.class.getName()));
+    assertTrue(opts.getModuleNames().contains(P6LogFactory.class.getName()));
+    assertEquals("", opts.getDriverlist());
+    assertNull(opts.getDriverNames());
+    assertFalse(opts.getStackTrace());
+    assertNull(opts.getStackTraceClass());
+    assertFalse(opts.getAutoflush());
+    assertFalse(opts.getReloadProperties());
+    assertEquals(60L, opts.getReloadPropertiesInterval());
+    assertNull(opts.getJNDIContextFactory());
+    assertNull(opts.getJNDIContextProviderURL());
+    assertNull(opts.getJNDIContextCustom());
+    assertNull(opts.getRealDataSource());
+    assertNull(opts.getRealDataSourceClass());
+    assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSZ", opts.getDatabaseDialectDateFormat());
+    assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSZ", opts.getDatabaseDialectTimestampFormat());
+    assertEquals("boolean", opts.getDatabaseDialectBooleanFormat());
+    assertEquals(String.format("%s|%s|%s|connection%s|%s",
       CustomLineFormat.CURRENT_TIME, CustomLineFormat.EXECUTION_TIME, CustomLineFormat.CATEGORY,
       CustomLineFormat.CONNECTION_ID, CustomLineFormat.SQL_SINGLE_LINE),
       opts.getCustomLogMessageFormat());
-    Assert.assertTrue(opts.getJmx());
-    Assert.assertNull(opts.getJmxPrefix());
+    assertTrue(opts.getJmx());
+    assertNull(opts.getJmxPrefix());
   }
 
   @Test
@@ -162,21 +169,21 @@ public class P6TestOptionDefaults extends BaseTestCase {
     }
 
     final P6LogLoadableOptions opts = P6LogOptions.getActiveInstance();
-    Assert.assertNotNull(opts);
+    assertNotNull(opts);
 
-    Assert.assertNull(opts.getSQLExpression());
-    Assert.assertEquals(0L, opts.getExecutionThreshold());
-    Assert.assertEquals("info,debug,result,resultset,batch", opts.getExcludecategories());
-    Assert.assertFalse(opts.getExcludebinary());
-    Assert.assertTrue(opts.getExcludeCategoriesSet().containsAll(
+    assertNull(opts.getSQLExpression());
+    assertEquals(0L, opts.getExecutionThreshold());
+    assertEquals("info,debug,result,resultset,batch", opts.getExcludecategories());
+    assertFalse(opts.getExcludebinary());
+    assertTrue(opts.getExcludeCategoriesSet().containsAll(
         Arrays.asList(DEFAULT_CATEGORIES)));
-    Assert.assertFalse(opts.getFilter());
-    Assert.assertNull(opts.getIncludeList());
-    Assert.assertNull(opts.getExcludeList());
-    Assert.assertNull(opts.getIncludeExcludePattern());
-    Assert.assertEquals("", opts.getInclude());
-    Assert.assertEquals("", opts.getExclude());
-    Assert.assertNull(opts.getSQLExpressionPattern());
+    assertFalse(opts.getFilter());
+    assertNull(opts.getIncludeList());
+    assertNull(opts.getExcludeList());
+    assertNull(opts.getIncludeExcludePattern());
+    assertEquals("", opts.getInclude());
+    assertEquals("", opts.getExclude());
+    assertNull(opts.getSQLExpressionPattern());
   }
 
   @Test
@@ -189,11 +196,11 @@ public class P6TestOptionDefaults extends BaseTestCase {
     }
 
     final P6OutageLoadableOptions opts = P6OutageOptions.getActiveInstance();
-    Assert.assertNotNull(opts);
+    assertNotNull(opts);
 
-    Assert.assertFalse(opts.getOutageDetection());
-    Assert.assertEquals(30L, opts.getOutageDetectionInterval());
-    Assert.assertEquals(30000L, opts.getOutageDetectionIntervalMS());
+    assertFalse(opts.getOutageDetection());
+    assertEquals(30L, opts.getOutageDetectionInterval());
+    assertEquals(30000L, opts.getOutageDetectionIntervalMS());
     
     // cleanup - make sure go back to default modules
     {
@@ -214,7 +221,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
       assertDefaultDisabledLogCategories();
     } catch(IOException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
     
     // cleanup - make sure go back to default modules
@@ -232,7 +239,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
       assertDefaultDisabledLogCategories();
     } catch(IOException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
   }
 
@@ -242,7 +249,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
       P6LogQuery.debug(msg);
       if( LOG_FILE.exists() ) {
         final String logged = FileUtils.readFileToString(LOG_FILE, "UTF-8");
-        Assert.assertFalse(logged.contains(msg));
+        assertFalse(logged.contains(msg));
       }
     }
     
@@ -251,7 +258,7 @@ public class P6TestOptionDefaults extends BaseTestCase {
       P6LogQuery.info(msg);
       if( LOG_FILE.exists() ) {
         final String logged = FileUtils.readFileToString(LOG_FILE, "UTF-8");
-        Assert.assertFalse(logged.contains(msg));
+        assertFalse(logged.contains(msg));
       }
     }
     
@@ -260,9 +267,9 @@ public class P6TestOptionDefaults extends BaseTestCase {
       P6LogQuery.error(msg);
       if( LOG_FILE.exists() ) {
         final String logged = FileUtils.readFileToString(LOG_FILE, "UTF-8");
-        Assert.assertTrue(logged.contains(msg));
+        assertTrue(logged.contains(msg));
       } else {
-        Assert.fail("log file not created");
+        fail("log file not created");
       }
     }
   }

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsReload.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsReload.java
@@ -17,8 +17,8 @@
  */
 package com.p6spy.engine.spy.option;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,25 +26,24 @@ import java.sql.SQLException;
 
 import javax.management.JMException;
 
-import com.p6spy.engine.test.BaseTestCase;
-
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.j256.simplejmx.client.JmxClient;
 import com.p6spy.engine.common.P6Util;
 import com.p6spy.engine.spy.P6MBeansRegistry;
 import com.p6spy.engine.spy.P6SpyOptions;
-import com.p6spy.engine.test.P6TestFramework;
 import com.p6spy.engine.spy.P6TestMBean;
+import com.p6spy.engine.test.BaseTestCase;
+import com.p6spy.engine.test.P6TestFramework;
 
 public class P6TestOptionsReload extends BaseTestCase {
 
   private JmxClient jmxClient = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws JMException, SQLException, IOException, InterruptedException {
     // make sure to reinit properly
     new P6TestFramework("reload") {
@@ -55,7 +54,7 @@ public class P6TestOptionsReload extends BaseTestCase {
     jmxClient = new JmxClient(jmxPort);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     // cleanup to make sure other tests work as expected
     System.getProperties().remove(SystemProperties.P6SPY_PREFIX + P6SpyOptions.STACKTRACE);

--- a/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsSources.java
+++ b/src/test/java/com/p6spy/engine/spy/option/P6TestOptionsSources.java
@@ -17,16 +17,18 @@
  */
 package com.p6spy.engine.spy.option;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
 
 import javax.management.JMException;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.logging.P6LogOptions;
 import com.p6spy.engine.test.BaseTestCase;
@@ -34,7 +36,7 @@ import com.p6spy.engine.test.P6TestFramework;
 
 public class P6TestOptionsSources extends BaseTestCase {
 
-	@Before
+	@BeforeEach
 	public void setUp() throws JMException, SQLException, IOException,
 			InterruptedException {
 		// make sure to reinit properly
@@ -42,7 +44,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		};
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		// cleanup to make sure other tests work as expected
 		System.getProperties().remove(
@@ -55,7 +57,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		new P6TestFramework("blank") {
 		};
 
-		Assert.assertTrue(P6LogOptions
+		assertTrue(P6LogOptions
 				.getActiveInstance()
 				.getExcludeCategoriesSet()
 				.containsAll(
@@ -68,7 +70,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		new P6TestFramework("override_clear") {
 		};
 
-		Assert.assertNull(P6LogOptions.getActiveInstance()
+		assertNull(P6LogOptions.getActiveInstance()
 				.getExcludeCategoriesSet());
 	}
 
@@ -78,7 +80,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		new P6TestFramework("blank") {
 		};
 
-		Assert.assertTrue(P6LogOptions
+		assertTrue(P6LogOptions
 				.getActiveInstance()
 				.getExcludeCategoriesSet()
 				.containsAll(
@@ -95,7 +97,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		new P6TestFramework("blank") {
 		};
 
-		Assert.assertNull(P6LogOptions.getActiveInstance()
+		assertNull(P6LogOptions.getActiveInstance()
 				.getExcludeCategoriesSet());
 	}
 	
@@ -105,7 +107,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 
 		P6LogOptions.getActiveInstance().setExcludecategories(null);
 		
-		Assert.assertTrue(P6LogOptions
+		assertTrue(P6LogOptions
 				.getActiveInstance()
 				.getExcludeCategoriesSet()
 				.containsAll(
@@ -118,7 +120,7 @@ public class P6TestOptionsSources extends BaseTestCase {
 		
 		P6LogOptions.getActiveInstance().setExcludecategories("");
 
-		Assert.assertNull(P6LogOptions.getActiveInstance()
+		assertNull(P6LogOptions.getActiveInstance()
 				.getExcludeCategoriesSet());
 	}
 }

--- a/src/test/java/com/p6spy/engine/spy/option/SpyDotPropertiesTest.java
+++ b/src/test/java/com/p6spy/engine/spy/option/SpyDotPropertiesTest.java
@@ -17,9 +17,9 @@
  */
 package com.p6spy.engine.spy.option;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,9 +29,9 @@ import java.net.URLClassLoader;
 import java.util.Properties;
 import java.util.UUID;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.p6spy.engine.test.BaseTestCase;
 
@@ -44,7 +44,7 @@ public class SpyDotPropertiesTest extends BaseTestCase {
   private ClassLoader currentThreadLoader;
   private File testFile;
 
-  @Before
+  @BeforeEach
   public void setup() {
     systemProps = new Properties();
     for( String key : System.getProperties().stringPropertyNames()) {
@@ -53,7 +53,7 @@ public class SpyDotPropertiesTest extends BaseTestCase {
     currentThreadLoader = Thread.currentThread().getContextClassLoader();
   }
   
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     System.setProperties(systemProps);
     Thread.currentThread().setContextClassLoader(currentThreadLoader);
@@ -71,7 +71,7 @@ public class SpyDotPropertiesTest extends BaseTestCase {
     // configure the file to load
     System.setProperty(SpyDotProperties.OPTIONS_FILE_PROPERTY, "SpyDotPropertiesTest.properties");
     SpyDotProperties props = new SpyDotProperties();
-    assertNotNull("properties not loaded!", props.getOptions());
+    assertNotNull( props.getOptions(),"properties not loaded!");
   }
 
   @Test
@@ -85,7 +85,7 @@ public class SpyDotPropertiesTest extends BaseTestCase {
     System.setProperty(SpyDotProperties.OPTIONS_FILE_PROPERTY, testFile.getName());
 
     SpyDotProperties props = new SpyDotProperties();
-    assertNotNull("properties not loaded!", props.getOptions());
+    assertNotNull( props.getOptions(),"properties not loaded!");
     
     if( !testFile.delete() ) {      
       // if the file was not closed properly, the delete will fail!
@@ -99,7 +99,7 @@ public class SpyDotPropertiesTest extends BaseTestCase {
     System.setProperty(SpyDotProperties.OPTIONS_FILE_PROPERTY, UUID.randomUUID().toString());
 
     SpyDotProperties props = new SpyDotProperties();
-    assertNull("properties loaded!", props.getOptions());
+    assertNull( props.getOptions(),"properties loaded!");
   }
 
 }

--- a/src/test/java/com/p6spy/engine/test/BaseTestCase.java
+++ b/src/test/java/com/p6spy/engine/test/BaseTestCase.java
@@ -17,21 +17,25 @@
  */
 package com.p6spy.engine.test;
 
-import com.p6spy.engine.event.JdbcEventListener;
 import org.apache.log4j.Logger;
 import org.junit.Rule;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
+
+import com.p6spy.engine.event.JdbcEventListener;
 
 /**
  * @author Quinton McCombs
  * @since 11/2013
  */
+@ExtendWith(TestExecutionLoggerExtension.class)
 public class BaseTestCase {
   private static final Logger log = Logger.getLogger(BaseTestCase.class);
   protected JdbcEventListener noOpEventListener = new JdbcEventListener() {};
 
+  //remove after junit5 migration 
   @Rule
   public TestRule testExecutionLogger = new TestWatcher() {
     /**
@@ -61,5 +65,5 @@ public class BaseTestCase {
     }
   };
 
-
 }
+

--- a/src/test/java/com/p6spy/engine/test/TestExecutionLoggerExtension.java
+++ b/src/test/java/com/p6spy/engine/test/TestExecutionLoggerExtension.java
@@ -1,0 +1,51 @@
+/**
+ * P6Spy
+ *
+ * Copyright (C) 2002 P6Spy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.p6spy.engine.test;
+
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+public class TestExecutionLoggerExtension  implements TestWatcher, BeforeTestExecutionCallback  {
+
+   private static final Logger log = Logger.getLogger(BaseTestCase.class);
+ 
+   @Override
+   public void testSuccessful(ExtensionContext context) {
+      log.info("Completed test " + context.getDisplayName());
+      TestWatcher.super.testSuccessful(context);
+   }
+
+   @Override
+   public void testFailed(ExtensionContext context, Throwable cause) {
+      log.error("Failed test " + context.getDisplayName(), cause);
+      TestWatcher.super.testFailed(context, cause);
+   }
+
+   @Override
+   public void beforeTestExecution(ExtensionContext context) throws Exception {
+      log.info("\n" + //
+            "*****************************************************************************************\n" + //
+            "\n" + //
+            "Executing test " + context.getDisplayName() + //
+            "\n" + //
+            "\n" + //
+            "*****************************************************************************************");
+   }
+}

--- a/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
+++ b/src/test/java/com/p6spy/engine/wrapper/ConnectionWrapperTest.java
@@ -17,17 +17,18 @@
  */
 package com.p6spy.engine.wrapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.sql.Connection;
 
 import javax.sql.DataSource;
 
+import org.junit.jupiter.api.Test;
+
 import com.p6spy.engine.common.ConnectionInformation;
 import com.p6spy.engine.event.JdbcEventListener;
-import org.junit.Test;
 
 public class ConnectionWrapperTest {
 


### PR DESCRIPTION
this pr migrates to JUnit5 all the tests that do not use the base class P6TestFramework. 
the gradle config has been changed to support both junit5- und junit-4 tests.

The test P6TestOptionsRepository is not in this PR, since the use of assertThrows with lambdas requires a base version of java 1.8. 